### PR TITLE
Migliora tab e gestione genere libro

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -132,6 +132,8 @@ function bookcreator_admin_assets( $hook ) {
     }
     wp_enqueue_script( 'jquery-ui-tabs' );
     wp_enqueue_media();
+    wp_enqueue_style( 'wp-jquery-ui-dialog' );
+    wp_enqueue_style( 'bookcreator-admin', plugins_url( 'css/admin.css', __FILE__ ), array(), '1.0.0' );
 }
 add_action( 'admin_enqueue_scripts', 'bookcreator_admin_assets' );
 
@@ -336,6 +338,7 @@ function bookcreator_create_page() {
                                     echo '<option value="' . esc_attr( $genre->term_id ) . '"' . selected( in_array( $genre->term_id, (array) $selected, true ), true, false ) . '>' . esc_html( $genre->name ) . '</option>';
                                 }
                                 echo '</select>';
+                                echo '<p><a href="' . esc_url( admin_url( 'edit-tags.php?taxonomy=book_genre&post_type=book_creator' ) ) . '">' . esc_html__( 'Gestisci generi', 'bookcreator' ) . '</a></p>';
                             }
                             ?>
                         </td>

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,0 +1,59 @@
+#bookcreator-tabs {
+    margin-top: 20px;
+}
+
+#bookcreator-tabs .ui-tabs-nav {
+    margin: 0 0 20px;
+    padding: 0;
+    list-style: none;
+}
+
+#bookcreator-tabs .ui-tabs-nav li {
+    display: inline-block;
+    margin: 0 4px 0 0;
+}
+
+#bookcreator-tabs .ui-tabs-nav li a {
+    display: block;
+    padding: 6px 12px;
+    background: #e5e5e5;
+    border: 1px solid #ccc;
+    border-bottom: none;
+    text-decoration: none;
+}
+
+#bookcreator-tabs .ui-tabs-nav li.ui-tabs-active a {
+    background: #fff;
+}
+
+#bookcreator-tabs .ui-tabs-panel {
+    border: 1px solid #ccc;
+    background: #fff;
+    padding: 20px;
+}
+
+#bookcreator-tabs .form-table {
+    width: 100%;
+}
+
+#bookcreator-tabs .form-table tr {
+    float: left;
+    width: 48%;
+    box-sizing: border-box;
+    margin-right: 4%;
+}
+
+#bookcreator-tabs .form-table tr:nth-child(2n) {
+    margin-right: 0;
+}
+
+#bookcreator-tabs .form-table th,
+#bookcreator-tabs .form-table td {
+    display: block;
+}
+
+#bookcreator-tabs .form-table::after {
+    content: '';
+    display: block;
+    clear: both;
+}


### PR DESCRIPTION
## Summary
- Style admin tabs and split form fields into two columns
- Allow quick access to manage book genres

## Testing
- `php -l bookcreator.php`

------
https://chatgpt.com/codex/tasks/task_e_68bdc6b7607c83328e0bdceab5916e20