### PR TITLE
Fix 'Genere Libro' menu link to genre management page

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -109,19 +109,10 @@ function bookcreator_admin_menu() {
         __( 'Genere Libro', 'bookcreator' ),
         __( 'Genere Libro', 'bookcreator' ),
         'manage_options',
-        'bookcreator_genres',
-        'bookcreator_redirect_genres'
+        'edit-tags.php?taxonomy=book_genre&post_type=book_creator'
     );
 }
 add_action( 'admin_menu', 'bookcreator_admin_menu' );
-
-/**
- * Redirects to taxonomy management page.
- */
-function bookcreator_redirect_genres() {
-    wp_redirect( admin_url( 'edit-tags.php?taxonomy=book_genre&post_type=book_creator' ) );
-    exit;
-}
 
 /**
  * Enqueue scripts for tabs.


### PR DESCRIPTION
## Summary
- Link the "Genere Libro" submenu directly to the taxonomy management screen so it matches the "Gestisci generi" section.
- Remove unnecessary redirect callback.

## Testing
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb00c3748332b34f0a00e736abe0