### PR TITLE
Fix chapter order saving

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -483,6 +483,8 @@ function bookcreator_order_chapters_page() {
 
         echo '<form id="update-nav-menu" method="post">';
         wp_nonce_field( 'bc_save_chapter_order' );
+        echo '<input type="hidden" name="menu" id="menu" value="' . esc_attr( $menu_id ) . '" />';
+        echo '<input type="hidden" name="menu-name" id="menu-name" value="chapters-book-' . esc_attr( $book_id ) . '" />';
         wp_nav_menu( array(
             'menu'        => $menu_id,
             'walker'      => new Walker_Nav_Menu_Edit,


### PR DESCRIPTION
## Summary
- ensure chapter ordering form includes necessary hidden fields so save button works

## Testing
- `php -l bookcreator.php`
- `composer validate --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_68beaed626c0833295573002c44151b2