### PR TITLE
Fix cover upload and add Retina cover support

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -205,16 +205,16 @@ function bookcreator_meta_box_descriptive( $post ) {
 }
 
 function bookcreator_meta_box_prelim( $post ) {
-    $cover_id      = get_post_meta( $post->ID, 'bc_cover', true );
-    $back_id       = get_post_meta( $post->ID, 'bc_back_cover', true );
+    $cover_id       = get_post_meta( $post->ID, 'bc_cover', true );
+    $retina_id      = get_post_meta( $post->ID, 'bc_retina_cover', true );
     ?>
     <p><label for="bc_cover"><?php esc_html_e( 'Copertina', 'bookcreator' ); ?></label><br/>
     <input type="file" name="bc_cover" id="bc_cover" /><br/>
     <?php if ( $cover_id ) { echo wp_get_attachment_image( $cover_id, array( 100, 100 ) ); } ?></p>
 
-    <p><label for="bc_back_cover"><?php esc_html_e( 'Copertina Retro', 'bookcreator' ); ?></label><br/>
-    <input type="file" name="bc_back_cover" id="bc_back_cover" /><br/>
-    <?php if ( $back_id ) { echo wp_get_attachment_image( $back_id, array( 100, 100 ) ); } ?></p>
+    <p><label for="bc_retina_cover"><?php esc_html_e( 'Copertina Retina Display', 'bookcreator' ); ?></label><br/>
+    <input type="file" name="bc_retina_cover" id="bc_retina_cover" /><br/>
+    <?php if ( $retina_id ) { echo wp_get_attachment_image( $retina_id, array( 100, 100 ) ); } ?></p>
 
     <p><label for="bc_frontispiece"><?php esc_html_e( 'Frontespizio', 'bookcreator' ); ?></label><br/>
     <textarea name="bc_frontispiece" id="bc_frontispiece" class="widefat" rows="3"><?php echo esc_textarea( get_post_meta( $post->ID, 'bc_frontispiece', true ) ); ?></textarea></p>
@@ -308,12 +308,13 @@ function bookcreator_save_meta( $post_id ) {
         }
     }
 
-    if ( ! empty( $_FILES['bc_back_cover']['name'] ) ) {
-        $back_cover_id = media_handle_upload( 'bc_back_cover', $post_id );
-        if ( ! is_wp_error( $back_cover_id ) ) {
-            update_post_meta( $post_id, 'bc_back_cover', $back_cover_id );
+    if ( ! empty( $_FILES['bc_retina_cover']['name'] ) ) {
+        $retina_cover_id = media_handle_upload( 'bc_retina_cover', $post_id );
+        if ( ! is_wp_error( $retina_cover_id ) ) {
+            update_post_meta( $post_id, 'bc_retina_cover', $retina_cover_id );
         }
     }
+
 }
 add_action( 'save_post_book_creator', 'bookcreator_save_meta' );
 
@@ -350,7 +351,7 @@ function bookcreator_set_custom_columns( $columns ) {
         'taxonomy-book_genre' => __( 'Genere Libro', 'bookcreator' ),
         'bc_language'         => __( 'Lingua', 'bookcreator' ),
         'bc_cover'            => __( 'Copertina', 'bookcreator' ),
-        'bc_back_cover'       => __( 'Copertina Retro', 'bookcreator' ),
+        'bc_retina_cover'     => __( 'Copertina Retina Display', 'bookcreator' ),
         'date'                => $columns['date'],
     );
 
@@ -387,16 +388,24 @@ function bookcreator_render_custom_columns( $column, $post_id ) {
         }
     }
 
-    if ( 'bc_back_cover' === $column ) {
-        $back_id = get_post_meta( $post_id, 'bc_back_cover', true );
-        if ( $back_id ) {
-            echo wp_get_attachment_image( $back_id, array( 50, 50 ) );
+    if ( 'bc_retina_cover' === $column ) {
+        $retina_id = get_post_meta( $post_id, 'bc_retina_cover', true );
+        if ( $retina_id ) {
+            echo wp_get_attachment_image( $retina_id, array( 50, 50 ) );
         } else {
             echo '—';
         }
     }
 }
 add_action( 'manage_book_creator_posts_custom_column', 'bookcreator_render_custom_columns', 10, 2 );
+
+function bookcreator_form_enctype() {
+    global $post;
+    if ( $post && 'book_creator' === $post->post_type ) {
+        echo ' enctype="multipart/form-data"';
+    }
+}
+add_action( 'post_edit_form_tag', 'bookcreator_form_enctype' );
 
 function bookcreator_get_chapter_menu_id( $book_id ) {
     $slug = 'chapters-book-' . $book_id;
@@ -547,7 +556,7 @@ function bookcreator_render_single_template( $template ) {
             'keywords'     => get_post_meta( $post_id, 'bc_keywords', true ),
             'audience'     => get_post_meta( $post_id, 'bc_audience', true ),
             'cover'        => wp_get_attachment_url( get_post_meta( $post_id, 'bc_cover', true ) ),
-            'back_cover'   => wp_get_attachment_url( get_post_meta( $post_id, 'bc_back_cover', true ) ),
+            'retina_cover' => wp_get_attachment_url( get_post_meta( $post_id, 'bc_retina_cover', true ) ),
             'frontispiece' => get_post_meta( $post_id, 'bc_frontispiece', true ),
             'copyright'    => get_post_meta( $post_id, 'bc_copyright', true ),
             'dedication'   => get_post_meta( $post_id, 'bc_dedication', true ),

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -34,6 +34,7 @@
 
 <section id="preliminary">
     {% if book.cover %}<img src="{{ book.cover }}" alt="Copertina" />{% endif %}
+    {% if book.retina_cover %}<img src="{{ book.retina_cover }}" alt="Copertina Retina Display" />{% endif %}
     {% if book.frontispiece %}<div class="frontispiece">{{ book.frontispiece|raw }}</div>{% endif %}
     {% if book.copyright %}<div class="copyright">{{ book.copyright|raw }}</div>{% endif %}
     {% if book.dedication %}<div class="dedication">{{ book.dedication|raw }}</div>{% endif %}


### PR DESCRIPTION
## Summary
- Rename "Copertina Retro" to "Copertina Retina Display" and update meta key to `bc_retina_cover`
- Enable file upload for covers by adding multipart form encoding
- Render Retina Display cover in admin columns and front-end Twig template

## Testing
- `php -l bookcreator.php`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68beb32c33e4833297e8af2e123fbbf2