### PR TITLE
Add basic book template management

### DIFF
--- a/templates/book.twig
+++ b/templates/book.twig
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>{{ book.title }}</title>
+    <title>{{ template.book_title|default(book.title) }}</title>
 </head>
 <body>
 <nav class="bc-nav">
@@ -15,7 +15,7 @@
 </nav>
 
 <section id="identification">
-    <h1>{{ book.title }}</h1>
+    <h1>{{ template.book_title|default(book.title) }}</h1>
     {% if book.subtitle %}<h2>{{ book.subtitle }}</h2>{% endif %}
     {% if book.author %}<p class="author">{{ book.author }}</p>{% endif %}
     {% if book.coauthors %}<p class="coauthors">{{ book.coauthors }}</p>{% endif %}

--- a/templates/template-form.twig
+++ b/templates/template-form.twig
@@ -1,0 +1,10 @@
+<p>
+    <label for="bc_template_book_title">{{ book_title_label }}</label><br />
+    <input type="text" name="bc_template_book_title" id="bc_template_book_title" value="{{ book_title }}" class="widefat" />
+</p>
+<p>
+    <label>
+        <input type="checkbox" name="bc_template_default" value="1" {% if default %}checked{% endif %} />
+        {{ default_label }}
+    </label>
+</p>


### PR DESCRIPTION
## Summary
- add `bc_template` post type and admin UI via Twig
- allow books to select templates with default option
- load template title in Twig output

## Testing
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68beccd2512c833280f12ccb93a2dd4c