### PR TITLE
Render chapters and paragraphs in book template

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -1058,7 +1058,43 @@ function bookcreator_render_single_template( $template ) {
             $template_data['book_title'] = get_post_meta( $template_id, 'bc_template_book_title', true );
         }
 
-        echo $twig->render( 'book.twig', array( 'book' => $book, 'template' => $template_data ) );
+        $chapters     = array();
+        $chapter_menu = wp_get_nav_menu_object( 'chapters-book-' . $post_id );
+        if ( $chapter_menu ) {
+            $chapter_items = wp_get_nav_menu_items( $chapter_menu->term_id );
+            if ( $chapter_items ) {
+                foreach ( $chapter_items as $item ) {
+                    if ( 'bc_chapter' !== $item->object ) {
+                        continue;
+                    }
+                    $chapter_id = (int) $item->object_id;
+                    $paragraphs = array();
+                    $para_menu  = wp_get_nav_menu_object( 'paragraphs-chapter-' . $chapter_id );
+                    if ( $para_menu ) {
+                        $para_items = wp_get_nav_menu_items( $para_menu->term_id );
+                        if ( $para_items ) {
+                            foreach ( $para_items as $p_item ) {
+                                if ( 'bc_paragraph' !== $p_item->object ) {
+                                    continue;
+                                }
+                                $pid          = (int) $p_item->object_id;
+                                $paragraphs[] = array(
+                                    'title'   => get_the_title( $pid ),
+                                    'content' => apply_filters( 'the_content', get_post_field( 'post_content', $pid ) ),
+                                );
+                            }
+                        }
+                    }
+                    $chapters[] = array(
+                        'title'      => get_the_title( $chapter_id ),
+                        'content'    => apply_filters( 'the_content', get_post_field( 'post_content', $chapter_id ) ),
+                        'paragraphs' => $paragraphs,
+                    );
+                }
+            }
+        }
+
+        echo $twig->render( 'book.twig', array( 'book' => $book, 'chapters' => $chapters, 'template' => $template_data ) );
         exit;
     }
 

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -5,17 +5,19 @@
     <title>{{ template.book_title|default(book.title) }}</title>
 </head>
 <body>
+<h1>{{ template.book_title|default(book.title) }}</h1>
+{% if book.cover %}<img src="{{ book.cover }}" alt="Cover" />{% endif %}
 <nav class="bc-nav">
     <ul>
         <li><a href="#identification">Identification</a></li>
         <li><a href="#descriptive">Descriptive</a></li>
         <li><a href="#preliminary">Preliminary Parts</a></li>
+        <li><a href="#chapters">Chapters</a></li>
         <li><a href="#final">Final Parts</a></li>
     </ul>
 </nav>
 
 <section id="identification">
-    <h1>{{ template.book_title|default(book.title) }}</h1>
     {% if book.subtitle %}<h2>{{ book.subtitle }}</h2>{% endif %}
     {% if book.author %}<p class="author">{{ book.author }}</p>{% endif %}
     {% if book.coauthors %}<p class="coauthors">{{ book.coauthors }}</p>{% endif %}
@@ -33,12 +35,26 @@
 </section>
 
 <section id="preliminary">
-    {% if book.cover %}<img src="{{ book.cover }}" alt="Cover" />{% endif %}
     {% if book.retina_cover %}<img src="{{ book.retina_cover }}" alt="Retina Cover" />{% endif %}
     {% if book.frontispiece %}<div class="frontispiece">{{ book.frontispiece|raw }}</div>{% endif %}
     {% if book.copyright %}<div class="copyright">{{ book.copyright|raw }}</div>{% endif %}
     {% if book.dedication %}<div class="dedication">{{ book.dedication|raw }}</div>{% endif %}
     {% if book.preface %}<div class="preface">{{ book.preface|raw }}</div>{% endif %}
+</section>
+
+<section id="chapters">
+    {% for chapter in chapters %}
+    <article class="chapter">
+        <h2>{{ chapter.title }}</h2>
+        {% if chapter.content %}<div class="chapter-content">{{ chapter.content|raw }}</div>{% endif %}
+        {% for paragraph in chapter.paragraphs %}
+        <div class="paragraph">
+            <h3>{{ paragraph.title }}</h3>
+            <div class="paragraph-content">{{ paragraph.content|raw }}</div>
+        </div>
+        {% endfor %}
+    </article>
+    {% endfor %}
 </section>
 
 <section id="final">


### PR DESCRIPTION
## Summary
- Move book title and cover to top of Twig template and add chapter navigation
- Render chapters and their paragraphs in assigned order within the book template
- Load ordered chapter and paragraph data when rendering a single book

## Testing
- `php -l bookcreator.php`

------
https://chatgpt.com/codex/tasks/task_e_68becf40b8c48332aafad8091cf8972b