### PR TITLE
Add font and color selectors for templates

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -432,6 +432,10 @@ function bookcreator_meta_box_template_details( $post ) {
     $doc_height       = get_post_meta( $post->ID, 'bc_doc_height', true );
     $doc_unit         = get_post_meta( $post->ID, 'bc_doc_unit', true );
     $font_family      = get_post_meta( $post->ID, 'bc_font_family', true );
+    $heading_font     = get_post_meta( $post->ID, 'bc_heading_font', true );
+    $heading_color    = get_post_meta( $post->ID, 'bc_heading_color', true );
+    $text_color       = get_post_meta( $post->ID, 'bc_text_color', true );
+    $background_color = get_post_meta( $post->ID, 'bc_background_color', true );
     $font_size        = get_post_meta( $post->ID, 'bc_font_size', true );
     $line_height      = get_post_meta( $post->ID, 'bc_line_height', true );
 
@@ -446,6 +450,10 @@ function bookcreator_meta_box_template_details( $post ) {
         'height_label'          => esc_html__( 'Height', 'bookcreator' ),
         'typography_label'      => esc_html__( 'Typography', 'bookcreator' ),
         'font_label'            => esc_html__( 'Font', 'bookcreator' ),
+        'heading_font_label'    => esc_html__( 'Heading Font', 'bookcreator' ),
+        'heading_color_label'   => esc_html__( 'Heading Color', 'bookcreator' ),
+        'text_color_label'      => esc_html__( 'Text Color', 'bookcreator' ),
+        'background_color_label'=> esc_html__( 'Background Color', 'bookcreator' ),
         'font_size_label'       => esc_html__( 'Font Size', 'bookcreator' ),
         'line_height_label'     => esc_html__( 'Line Height', 'bookcreator' ),
         'default'               => $default,
@@ -455,6 +463,10 @@ function bookcreator_meta_box_template_details( $post ) {
         'doc_height'            => esc_attr( $doc_height ),
         'doc_unit'              => esc_attr( $doc_unit ),
         'font_family'           => esc_attr( $font_family ),
+        'heading_font'          => esc_attr( $heading_font ),
+        'heading_color'         => esc_attr( $heading_color ),
+        'text_color'            => esc_attr( $text_color ),
+        'background_color'      => esc_attr( $background_color ),
         'font_size'             => esc_attr( $font_size ),
         'line_height'           => esc_attr( $line_height ),
     ) );
@@ -542,6 +554,10 @@ function bookcreator_save_template_meta( $post_id ) {
         'bc_doc_height'      => 'floatval',
         'bc_doc_unit'        => 'sanitize_text_field',
         'bc_font_family'     => 'sanitize_text_field',
+        'bc_heading_font'    => 'sanitize_text_field',
+        'bc_heading_color'   => 'sanitize_hex_color',
+        'bc_text_color'      => 'sanitize_hex_color',
+        'bc_background_color'=> 'sanitize_hex_color',
         'bc_font_size'       => 'sanitize_text_field',
         'bc_line_height'     => 'sanitize_text_field',
     );
@@ -1102,6 +1118,10 @@ function bookcreator_render_single_template( $template ) {
                 'doc_height'      => 'bc_doc_height',
                 'doc_unit'        => 'bc_doc_unit',
                 'font_family'     => 'bc_font_family',
+                'heading_font'    => 'bc_heading_font',
+                'heading_color'   => 'bc_heading_color',
+                'text_color'      => 'bc_text_color',
+                'background_color'=> 'bc_background_color',
                 'font_size'       => 'bc_font_size',
                 'line_height'     => 'bc_line_height',
             );

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -6,7 +6,19 @@
     <link rel="stylesheet" href="{{ plugin_url }}css/style.css" />
     <link rel="stylesheet" href="{{ plugin_url }}css/paged.css" media="print" />
     <script src="https://unpkg.com/pagedjs/dist/paged.polyfill.js"></script>
-    {% if template.doc_format or template.doc_width or template.font_family or template.font_size or template.line_height %}
+    {% set google_fonts = {
+        'Source Serif Pro': 'Source+Serif+Pro',
+        'Crimson Text': 'Crimson+Text',
+        'Libre Baskerville': 'Libre+Baskerville',
+        'PT Serif': 'PT+Serif'
+    } %}
+    {% if template.font_family in google_fonts %}
+    <link href="https://fonts.googleapis.com/css2?family={{ google_fonts[template.font_family] }}&display=swap" rel="stylesheet" />
+    {% endif %}
+    {% if template.heading_font in google_fonts and template.heading_font != template.font_family %}
+    <link href="https://fonts.googleapis.com/css2?family={{ google_fonts[template.heading_font] }}&display=swap" rel="stylesheet" />
+    {% endif %}
+    {% if template.doc_format or template.doc_width or template.font_family or template.font_size or template.line_height or template.heading_font or template.heading_color or template.text_color or template.background_color %}
     <style>
     @page {
         {% if template.doc_format and template.doc_format != 'Custom' %}
@@ -16,9 +28,18 @@
         {% endif %}
     }
     body {
-        {% if template.font_family %}font-family: {{ template.font_family }};{% endif %}
+        {% if template.font_family %}font-family: '{{ template.font_family }}', serif;{% endif %}
         {% if template.font_size %}font-size: {{ template.font_size }};{% endif %}
         {% if template.line_height %}line-height: {{ template.line_height }};{% endif %}
+        {% if template.text_color %}color: {{ template.text_color }};{% endif %}
+        {% if template.background_color %}background-color: {{ template.background_color }};{% endif %}
+    }
+    h1, h2, h3, h4, h5, h6 {
+        {% if template.heading_font %}font-family: '{{ template.heading_font }}', sans-serif;{% endif %}
+        {% if template.heading_color %}color: {{ template.heading_color }};{% endif %}
+    }
+    code, pre {
+        font-family: 'Courier New', Courier, monospace;
     }
     </style>
     {% endif %}

--- a/templates/template-form.twig
+++ b/templates/template-form.twig
@@ -35,7 +35,46 @@
 <h4>{{ typography_label }}</h4>
 <p>
     <label for="bc_font_family">{{ font_label }}</label><br />
-    <input type="text" name="bc_font_family" id="bc_font_family" value="{{ font_family }}" class="widefat" />
+    <select name="bc_font_family" id="bc_font_family" class="widefat">
+        <option value="" {% if font_family == '' %}selected{% endif %}>Default</option>
+        <optgroup label="System Serif">
+            <option value="Times New Roman" {% if font_family == 'Times New Roman' %}selected{% endif %}>Times New Roman</option>
+            <option value="Georgia" {% if font_family == 'Georgia' %}selected{% endif %}>Georgia</option>
+            <option value="Garamond" {% if font_family == 'Garamond' %}selected{% endif %}>Garamond</option>
+            <option value="Book Antiqua" {% if font_family == 'Book Antiqua' %}selected{% endif %}>Book Antiqua</option>
+        </optgroup>
+        <optgroup label="Google Serif">
+            <option value="Source Serif Pro" {% if font_family == 'Source Serif Pro' %}selected{% endif %}>Source Serif Pro</option>
+            <option value="Crimson Text" {% if font_family == 'Crimson Text' %}selected{% endif %}>Crimson Text</option>
+            <option value="Libre Baskerville" {% if font_family == 'Libre Baskerville' %}selected{% endif %}>Libre Baskerville</option>
+            <option value="PT Serif" {% if font_family == 'PT Serif' %}selected{% endif %}>PT Serif</option>
+        </optgroup>
+        <optgroup label="Monospace">
+            <option value="Courier New" {% if font_family == 'Courier New' %}selected{% endif %}>Courier New</option>
+        </optgroup>
+    </select>
+</p>
+<p>
+    <label for="bc_heading_font">{{ heading_font_label }}</label><br />
+    <select name="bc_heading_font" id="bc_heading_font" class="widefat">
+        <option value="" {% if heading_font == '' %}selected{% endif %}>Default</option>
+        <option value="Arial" {% if heading_font == 'Arial' %}selected{% endif %}>Arial</option>
+        <option value="Helvetica" {% if heading_font == 'Helvetica' %}selected{% endif %}>Helvetica</option>
+        <option value="Verdana" {% if heading_font == 'Verdana' %}selected{% endif %}>Verdana</option>
+        <option value="Tahoma" {% if heading_font == 'Tahoma' %}selected{% endif %}>Tahoma</option>
+    </select>
+</p>
+<p>
+    <label for="bc_heading_color">{{ heading_color_label }}</label><br />
+    <input type="color" name="bc_heading_color" id="bc_heading_color" value="{{ heading_color }}" />
+</p>
+<p>
+    <label for="bc_text_color">{{ text_color_label }}</label><br />
+    <input type="color" name="bc_text_color" id="bc_text_color" value="{{ text_color }}" />
+</p>
+<p>
+    <label for="bc_background_color">{{ background_color_label }}</label><br />
+    <input type="color" name="bc_background_color" id="bc_background_color" value="{{ background_color }}" />
 </p>
 <p>
     <label for="bc_font_size">{{ font_size_label }}</label>


### PR DESCRIPTION
## Summary
- add font family selection and heading font menu in template settings
- allow choosing heading, text, and background colors
- load Google fonts and apply chosen colors in book template

## Testing
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68befb4d40e083328736e547880ebe06