### PR TITLE
Add per-heading heading style options

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -432,12 +432,21 @@ function bookcreator_meta_box_template_details( $post ) {
     $doc_height       = get_post_meta( $post->ID, 'bc_doc_height', true );
     $doc_unit         = get_post_meta( $post->ID, 'bc_doc_unit', true );
     $font_family      = get_post_meta( $post->ID, 'bc_font_family', true );
-    $heading_font     = get_post_meta( $post->ID, 'bc_heading_font', true );
-    $heading_color    = get_post_meta( $post->ID, 'bc_heading_color', true );
     $text_color       = get_post_meta( $post->ID, 'bc_text_color', true );
     $background_color = get_post_meta( $post->ID, 'bc_background_color', true );
     $font_size        = get_post_meta( $post->ID, 'bc_font_size', true );
     $line_height      = get_post_meta( $post->ID, 'bc_line_height', true );
+
+    $headings = array();
+    for ( $i = 1; $i <= 5; $i++ ) {
+        $headings[ 'h' . $i ] = array(
+            'font'             => get_post_meta( $post->ID, 'bc_h' . $i . '_font', true ),
+            'color'            => get_post_meta( $post->ID, 'bc_h' . $i . '_color', true ),
+            'background_color' => get_post_meta( $post->ID, 'bc_h' . $i . '_background_color', true ),
+            'font_size'        => get_post_meta( $post->ID, 'bc_h' . $i . '_font_size', true ),
+            'line_height'      => get_post_meta( $post->ID, 'bc_h' . $i . '_line_height', true ),
+        );
+    }
 
     echo $twig->render( 'template-form.twig', array(
         'default_label'         => esc_html__( 'Default Template', 'bookcreator' ),
@@ -450,12 +459,11 @@ function bookcreator_meta_box_template_details( $post ) {
         'height_label'          => esc_html__( 'Height', 'bookcreator' ),
         'typography_label'      => esc_html__( 'Typography', 'bookcreator' ),
         'font_label'            => esc_html__( 'Font', 'bookcreator' ),
-        'heading_font_label'    => esc_html__( 'Heading Font', 'bookcreator' ),
-        'heading_color_label'   => esc_html__( 'Heading Color', 'bookcreator' ),
         'text_color_label'      => esc_html__( 'Text Color', 'bookcreator' ),
         'background_color_label'=> esc_html__( 'Background Color', 'bookcreator' ),
         'font_size_label'       => esc_html__( 'Font Size', 'bookcreator' ),
         'line_height_label'     => esc_html__( 'Line Height', 'bookcreator' ),
+        'heading_settings_label'=> esc_html__( 'Heading Styles', 'bookcreator' ),
         'default'               => $default,
         'doc_format'            => esc_attr( $doc_format ),
         'doc_orientation'       => esc_attr( $doc_orientation ),
@@ -463,12 +471,11 @@ function bookcreator_meta_box_template_details( $post ) {
         'doc_height'            => esc_attr( $doc_height ),
         'doc_unit'              => esc_attr( $doc_unit ),
         'font_family'           => esc_attr( $font_family ),
-        'heading_font'          => esc_attr( $heading_font ),
-        'heading_color'         => esc_attr( $heading_color ),
         'text_color'            => esc_attr( $text_color ),
         'background_color'      => esc_attr( $background_color ),
         'font_size'             => esc_attr( $font_size ),
         'line_height'           => esc_attr( $line_height ),
+        'headings'              => $headings,
     ) );
 }
 
@@ -554,13 +561,19 @@ function bookcreator_save_template_meta( $post_id ) {
         'bc_doc_height'      => 'floatval',
         'bc_doc_unit'        => 'sanitize_text_field',
         'bc_font_family'     => 'sanitize_text_field',
-        'bc_heading_font'    => 'sanitize_text_field',
-        'bc_heading_color'   => 'sanitize_hex_color',
         'bc_text_color'      => 'sanitize_hex_color',
         'bc_background_color'=> 'sanitize_hex_color',
         'bc_font_size'       => 'sanitize_text_field',
         'bc_line_height'     => 'sanitize_text_field',
     );
+
+    for ( $i = 1; $i <= 5; $i++ ) {
+        $fields[ 'bc_h' . $i . '_font' ]             = 'sanitize_text_field';
+        $fields[ 'bc_h' . $i . '_color' ]            = 'sanitize_hex_color';
+        $fields[ 'bc_h' . $i . '_background_color' ] = 'sanitize_hex_color';
+        $fields[ 'bc_h' . $i . '_font_size' ]        = 'sanitize_text_field';
+        $fields[ 'bc_h' . $i . '_line_height' ]      = 'sanitize_text_field';
+    }
 
     foreach ( $fields as $field => $sanitize ) {
         if ( isset( $_POST[ $field ] ) ) {
@@ -1118,13 +1131,20 @@ function bookcreator_render_single_template( $template ) {
                 'doc_height'      => 'bc_doc_height',
                 'doc_unit'        => 'bc_doc_unit',
                 'font_family'     => 'bc_font_family',
-                'heading_font'    => 'bc_heading_font',
-                'heading_color'   => 'bc_heading_color',
                 'text_color'      => 'bc_text_color',
                 'background_color'=> 'bc_background_color',
                 'font_size'       => 'bc_font_size',
                 'line_height'     => 'bc_line_height',
             );
+
+            for ( $i = 1; $i <= 5; $i++ ) {
+                $template_fields[ 'h' . $i . '_font' ]             = 'bc_h' . $i . '_font';
+                $template_fields[ 'h' . $i . '_color' ]            = 'bc_h' . $i . '_color';
+                $template_fields[ 'h' . $i . '_background_color' ] = 'bc_h' . $i . '_background_color';
+                $template_fields[ 'h' . $i . '_font_size' ]        = 'bc_h' . $i . '_font_size';
+                $template_fields[ 'h' . $i . '_line_height' ]      = 'bc_h' . $i . '_line_height';
+            }
+
             foreach ( $template_fields as $key => $meta_key ) {
                 $template_data[ $key ] = get_post_meta( $template_id, $meta_key, true );
             }

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -12,13 +12,24 @@
         'Libre Baskerville': 'Libre+Baskerville',
         'PT Serif': 'PT+Serif'
     } %}
+    {% set loaded_fonts = [] %}
     {% if template.font_family in google_fonts %}
     <link href="https://fonts.googleapis.com/css2?family={{ google_fonts[template.font_family] }}&display=swap" rel="stylesheet" />
+    {% set loaded_fonts = loaded_fonts|merge([template.font_family]) %}
     {% endif %}
-    {% if template.heading_font in google_fonts and template.heading_font != template.font_family %}
-    <link href="https://fonts.googleapis.com/css2?family={{ google_fonts[template.heading_font] }}&display=swap" rel="stylesheet" />
-    {% endif %}
-    {% if template.doc_format or template.doc_width or template.font_family or template.font_size or template.line_height or template.heading_font or template.heading_color or template.text_color or template.background_color %}
+    {% for i in 1..5 %}
+        {% set hf = attribute(template, 'h' ~ i ~ '_font') %}
+        {% if hf in google_fonts and hf not in loaded_fonts %}
+    <link href="https://fonts.googleapis.com/css2?family={{ google_fonts[hf] }}&display=swap" rel="stylesheet" />
+    {% set loaded_fonts = loaded_fonts|merge([hf]) %}
+        {% endif %}
+    {% endfor %}
+    {% if template.doc_format or template.doc_width or template.font_family or template.font_size or template.line_height or template.text_color or template.background_color
+        or template.h1_font or template.h1_color or template.h1_background_color or template.h1_font_size or template.h1_line_height
+        or template.h2_font or template.h2_color or template.h2_background_color or template.h2_font_size or template.h2_line_height
+        or template.h3_font or template.h3_color or template.h3_background_color or template.h3_font_size or template.h3_line_height
+        or template.h4_font or template.h4_color or template.h4_background_color or template.h4_font_size or template.h4_line_height
+        or template.h5_font or template.h5_color or template.h5_background_color or template.h5_font_size or template.h5_line_height %}
     <style>
     @page {
         {% if template.doc_format and template.doc_format != 'Custom' %}
@@ -34,10 +45,20 @@
         {% if template.text_color %}color: {{ template.text_color }};{% endif %}
         {% if template.background_color %}background-color: {{ template.background_color }};{% endif %}
     }
-    h1, h2, h3, h4, h5, h6 {
-        {% if template.heading_font %}font-family: '{{ template.heading_font }}', sans-serif;{% endif %}
-        {% if template.heading_color %}color: {{ template.heading_color }};{% endif %}
+    {% for i in 1..5 %}
+    h{{ i }} {
+        {% set hf = attribute(template, 'h' ~ i ~ '_font') %}
+        {% if hf %}font-family: '{{ hf }}', sans-serif;{% endif %}
+        {% set hc = attribute(template, 'h' ~ i ~ '_color') %}
+        {% if hc %}color: {{ hc }};{% endif %}
+        {% set hbg = attribute(template, 'h' ~ i ~ '_background_color') %}
+        {% if hbg %}background-color: {{ hbg }};{% endif %}
+        {% set hfs = attribute(template, 'h' ~ i ~ '_font_size') %}
+        {% if hfs %}font-size: {{ hfs }};{% endif %}
+        {% set hlh = attribute(template, 'h' ~ i ~ '_line_height') %}
+        {% if hlh %}line-height: {{ hlh }};{% endif %}
     }
+    {% endfor %}
     code, pre {
         font-family: 'Courier New', Courier, monospace;
     }

--- a/templates/template-form.twig
+++ b/templates/template-form.twig
@@ -55,20 +55,6 @@
     </select>
 </p>
 <p>
-    <label for="bc_heading_font">{{ heading_font_label }}</label><br />
-    <select name="bc_heading_font" id="bc_heading_font" class="widefat">
-        <option value="" {% if heading_font == '' %}selected{% endif %}>Default</option>
-        <option value="Arial" {% if heading_font == 'Arial' %}selected{% endif %}>Arial</option>
-        <option value="Helvetica" {% if heading_font == 'Helvetica' %}selected{% endif %}>Helvetica</option>
-        <option value="Verdana" {% if heading_font == 'Verdana' %}selected{% endif %}>Verdana</option>
-        <option value="Tahoma" {% if heading_font == 'Tahoma' %}selected{% endif %}>Tahoma</option>
-    </select>
-</p>
-<p>
-    <label for="bc_heading_color">{{ heading_color_label }}</label><br />
-    <input type="color" name="bc_heading_color" id="bc_heading_color" value="{{ heading_color }}" />
-</p>
-<p>
     <label for="bc_text_color">{{ text_color_label }}</label><br />
     <input type="color" name="bc_text_color" id="bc_text_color" value="{{ text_color }}" />
 </p>
@@ -82,3 +68,32 @@
     <label for="bc_line_height">{{ line_height_label }}</label>
     <input type="number" step="0.1" name="bc_line_height" id="bc_line_height" value="{{ line_height }}" class="small-text" />
 </p>
+
+<h4>{{ heading_settings_label }}</h4>
+{% for i in 1..5 %}
+<h5>H{{ i }}</h5>
+<p>
+    <label for="bc_h{{ i }}_font">{{ font_label }}</label><br />
+    <select name="bc_h{{ i }}_font" id="bc_h{{ i }}_font" class="widefat">
+        <option value="" {% if headings['h' ~ i].font == '' %}selected{% endif %}>Default</option>
+        <option value="Arial" {% if headings['h' ~ i].font == 'Arial' %}selected{% endif %}>Arial</option>
+        <option value="Helvetica" {% if headings['h' ~ i].font == 'Helvetica' %}selected{% endif %}>Helvetica</option>
+        <option value="Verdana" {% if headings['h' ~ i].font == 'Verdana' %}selected{% endif %}>Verdana</option>
+        <option value="Tahoma" {% if headings['h' ~ i].font == 'Tahoma' %}selected{% endif %}>Tahoma</option>
+    </select>
+</p>
+<p>
+    <label for="bc_h{{ i }}_color">{{ text_color_label }}</label><br />
+    <input type="color" name="bc_h{{ i }}_color" id="bc_h{{ i }}_color" value="{{ headings['h' ~ i].color }}" />
+</p>
+<p>
+    <label for="bc_h{{ i }}_background_color">{{ background_color_label }}</label><br />
+    <input type="color" name="bc_h{{ i }}_background_color" id="bc_h{{ i }}_background_color" value="{{ headings['h' ~ i].background_color }}" />
+</p>
+<p>
+    <label for="bc_h{{ i }}_font_size">{{ font_size_label }}</label>
+    <input type="number" step="0.1" name="bc_h{{ i }}_font_size" id="bc_h{{ i }}_font_size" value="{{ headings['h' ~ i].font_size }}" class="small-text" />
+    <label for="bc_h{{ i }}_line_height">{{ line_height_label }}</label>
+    <input type="number" step="0.1" name="bc_h{{ i }}_line_height" id="bc_h{{ i }}_line_height" value="{{ headings['h' ~ i].line_height }}" class="small-text" />
+</p>
+{% endfor %}


### PR DESCRIPTION
## Summary
- allow configuring font, text color, background color, font size, and line height for headings H1–H5
- save and apply these per-level heading styles when rendering templates

## Testing
- `php -l bookcreator.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68befe43e7708332a6ee086987e1fbf6