### PR TITLE
Improve template text controls and heading layout

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -436,6 +436,7 @@ function bookcreator_meta_box_template_details( $post ) {
     $background_color = get_post_meta( $post->ID, 'bc_background_color', true );
     $font_size        = get_post_meta( $post->ID, 'bc_font_size', true );
     $line_height      = get_post_meta( $post->ID, 'bc_line_height', true );
+    $text_unit        = get_post_meta( $post->ID, 'bc_text_unit', true );
 
     $headings = array();
     for ( $i = 1; $i <= 5; $i++ ) {
@@ -457,12 +458,13 @@ function bookcreator_meta_box_template_details( $post ) {
         'landscape_label'       => esc_html__( 'Landscape', 'bookcreator' ),
         'width_label'           => esc_html__( 'Width', 'bookcreator' ),
         'height_label'          => esc_html__( 'Height', 'bookcreator' ),
-        'typography_label'      => esc_html__( 'Typography', 'bookcreator' ),
+        'body_text_label'       => esc_html__( 'Body Text', 'bookcreator' ),
         'font_label'            => esc_html__( 'Font', 'bookcreator' ),
         'text_color_label'      => esc_html__( 'Text Color', 'bookcreator' ),
         'background_color_label'=> esc_html__( 'Background Color', 'bookcreator' ),
         'font_size_label'       => esc_html__( 'Font Size', 'bookcreator' ),
         'line_height_label'     => esc_html__( 'Line Height', 'bookcreator' ),
+        'text_unit_label'       => esc_html__( 'Text Unit', 'bookcreator' ),
         'heading_settings_label'=> esc_html__( 'Heading Styles', 'bookcreator' ),
         'default'               => $default,
         'doc_format'            => esc_attr( $doc_format ),
@@ -475,6 +477,7 @@ function bookcreator_meta_box_template_details( $post ) {
         'background_color'      => esc_attr( $background_color ),
         'font_size'             => esc_attr( $font_size ),
         'line_height'           => esc_attr( $line_height ),
+        'text_unit'             => esc_attr( $text_unit ),
         'headings'              => $headings,
     ) );
 }
@@ -565,6 +568,7 @@ function bookcreator_save_template_meta( $post_id ) {
         'bc_background_color'=> 'sanitize_hex_color',
         'bc_font_size'       => 'sanitize_text_field',
         'bc_line_height'     => 'sanitize_text_field',
+        'bc_text_unit'       => 'sanitize_text_field',
     );
 
     for ( $i = 1; $i <= 5; $i++ ) {
@@ -1135,6 +1139,7 @@ function bookcreator_render_single_template( $template ) {
                 'background_color'=> 'bc_background_color',
                 'font_size'       => 'bc_font_size',
                 'line_height'     => 'bc_line_height',
+                'text_unit'       => 'bc_text_unit',
             );
 
             for ( $i = 1; $i <= 5; $i++ ) {

--- a/css/admin.css
+++ b/css/admin.css
@@ -57,3 +57,14 @@
     display: block;
     clear: both;
 }
+
+.bc-heading-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.bc-heading-grid .bc-heading-item {
+    flex: 1 1 45%;
+    min-width: 220px;
+}

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -31,6 +31,7 @@
         or template.h4_font or template.h4_color or template.h4_background_color or template.h4_font_size or template.h4_line_height
         or template.h5_font or template.h5_color or template.h5_background_color or template.h5_font_size or template.h5_line_height %}
     <style>
+    {% set text_unit = template.text_unit ?: 'pt' %}
     @page {
         {% if template.doc_format and template.doc_format != 'Custom' %}
         size: {{ template.doc_format }}{% if template.doc_orientation %} {{ template.doc_orientation }}{% endif %};
@@ -40,8 +41,8 @@
     }
     body {
         {% if template.font_family %}font-family: '{{ template.font_family }}', serif;{% endif %}
-        {% if template.font_size %}font-size: {{ template.font_size }};{% endif %}
-        {% if template.line_height %}line-height: {{ template.line_height }};{% endif %}
+        {% if template.font_size %}font-size: {{ template.font_size }}{{ text_unit }};{% endif %}
+        {% if template.line_height %}line-height: {{ template.line_height }}{{ text_unit }};{% endif %}
         {% if template.text_color %}color: {{ template.text_color }};{% endif %}
         {% if template.background_color %}background-color: {{ template.background_color }};{% endif %}
     }
@@ -54,9 +55,9 @@
         {% set hbg = attribute(template, 'h' ~ i ~ '_background_color') %}
         {% if hbg %}background-color: {{ hbg }};{% endif %}
         {% set hfs = attribute(template, 'h' ~ i ~ '_font_size') %}
-        {% if hfs %}font-size: {{ hfs }};{% endif %}
+        {% if hfs %}font-size: {{ hfs }}{{ text_unit }};{% endif %}
         {% set hlh = attribute(template, 'h' ~ i ~ '_line_height') %}
-        {% if hlh %}line-height: {{ hlh }};{% endif %}
+        {% if hlh %}line-height: {{ hlh }}{{ text_unit }};{% endif %}
     }
     {% endfor %}
     code, pre {

--- a/templates/template-form.twig
+++ b/templates/template-form.twig
@@ -32,7 +32,7 @@
     </select>
 </p>
 
-<h4>{{ typography_label }}</h4>
+<h4>{{ body_text_label }}</h4>
 <p>
     <label for="bc_font_family">{{ font_label }}</label><br />
     <select name="bc_font_family" id="bc_font_family" class="widefat">
@@ -68,32 +68,44 @@
     <label for="bc_line_height">{{ line_height_label }}</label>
     <input type="number" step="0.1" name="bc_line_height" id="bc_line_height" value="{{ line_height }}" class="small-text" />
 </p>
-
-<h4>{{ heading_settings_label }}</h4>
-{% for i in 1..5 %}
-<h5>H{{ i }}</h5>
 <p>
-    <label for="bc_h{{ i }}_font">{{ font_label }}</label><br />
-    <select name="bc_h{{ i }}_font" id="bc_h{{ i }}_font" class="widefat">
-        <option value="" {% if headings['h' ~ i].font == '' %}selected{% endif %}>Default</option>
-        <option value="Arial" {% if headings['h' ~ i].font == 'Arial' %}selected{% endif %}>Arial</option>
-        <option value="Helvetica" {% if headings['h' ~ i].font == 'Helvetica' %}selected{% endif %}>Helvetica</option>
-        <option value="Verdana" {% if headings['h' ~ i].font == 'Verdana' %}selected{% endif %}>Verdana</option>
-        <option value="Tahoma" {% if headings['h' ~ i].font == 'Tahoma' %}selected{% endif %}>Tahoma</option>
+    <label for="bc_text_unit">{{ text_unit_label }}</label>
+    <select name="bc_text_unit" id="bc_text_unit">
+        <option value="pt" {% if text_unit == 'pt' or text_unit == '' %}selected{% endif %}>pt</option>
+        <option value="px" {% if text_unit == 'px' %}selected{% endif %}>px</option>
+        <option value="rem" {% if text_unit == 'rem' %}selected{% endif %}>rem</option>
     </select>
 </p>
-<p>
-    <label for="bc_h{{ i }}_color">{{ text_color_label }}</label><br />
-    <input type="color" name="bc_h{{ i }}_color" id="bc_h{{ i }}_color" value="{{ headings['h' ~ i].color }}" />
-</p>
-<p>
-    <label for="bc_h{{ i }}_background_color">{{ background_color_label }}</label><br />
-    <input type="color" name="bc_h{{ i }}_background_color" id="bc_h{{ i }}_background_color" value="{{ headings['h' ~ i].background_color }}" />
-</p>
-<p>
-    <label for="bc_h{{ i }}_font_size">{{ font_size_label }}</label>
-    <input type="number" step="0.1" name="bc_h{{ i }}_font_size" id="bc_h{{ i }}_font_size" value="{{ headings['h' ~ i].font_size }}" class="small-text" />
-    <label for="bc_h{{ i }}_line_height">{{ line_height_label }}</label>
-    <input type="number" step="0.1" name="bc_h{{ i }}_line_height" id="bc_h{{ i }}_line_height" value="{{ headings['h' ~ i].line_height }}" class="small-text" />
-</p>
+
+<h4>{{ heading_settings_label }}</h4>
+<div class="bc-heading-grid">
+{% for i in 1..5 %}
+    <div class="bc-heading-item">
+        <h5>H{{ i }}</h5>
+        <p>
+            <label for="bc_h{{ i }}_font">{{ font_label }}</label><br />
+            <select name="bc_h{{ i }}_font" id="bc_h{{ i }}_font" class="widefat">
+                <option value="" {% if headings['h' ~ i].font == '' %}selected{% endif %}>Default</option>
+                <option value="Arial" {% if headings['h' ~ i].font == 'Arial' %}selected{% endif %}>Arial</option>
+                <option value="Helvetica" {% if headings['h' ~ i].font == 'Helvetica' %}selected{% endif %}>Helvetica</option>
+                <option value="Verdana" {% if headings['h' ~ i].font == 'Verdana' %}selected{% endif %}>Verdana</option>
+                <option value="Tahoma" {% if headings['h' ~ i].font == 'Tahoma' %}selected{% endif %}>Tahoma</option>
+            </select>
+        </p>
+        <p>
+            <label for="bc_h{{ i }}_color">{{ text_color_label }}</label><br />
+            <input type="color" name="bc_h{{ i }}_color" id="bc_h{{ i }}_color" value="{{ headings['h' ~ i].color }}" />
+        </p>
+        <p>
+            <label for="bc_h{{ i }}_background_color">{{ background_color_label }}</label><br />
+            <input type="color" name="bc_h{{ i }}_background_color" id="bc_h{{ i }}_background_color" value="{{ headings['h' ~ i].background_color }}" />
+        </p>
+        <p>
+            <label for="bc_h{{ i }}_font_size">{{ font_size_label }}</label>
+            <input type="number" step="0.1" name="bc_h{{ i }}_font_size" id="bc_h{{ i }}_font_size" value="{{ headings['h' ~ i].font_size }}" class="small-text" />
+            <label for="bc_h{{ i }}_line_height">{{ line_height_label }}</label>
+            <input type="number" step="0.1" name="bc_h{{ i }}_line_height" id="bc_h{{ i }}_line_height" value="{{ headings['h' ~ i].line_height }}" class="small-text" />
+        </p>
+    </div>
 {% endfor %}
+</div>


### PR DESCRIPTION
## Summary
- Add body text configuration section with unit selector (pt, px, rem)
- Append chosen unit to all font sizes and line heights in book output
- Arrange heading options in a responsive grid for reduced vertical space

## Testing
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0292a63c83329596908ed0dbe437