### PR TITLE
Use WordPress color picker and improve template settings

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -602,6 +602,20 @@ function bookcreator_save_template_meta( $post_id ) {
 }
 add_action( 'save_post_bc_template', 'bookcreator_save_template_meta' );
 
+function bookcreator_template_admin_enqueue( $hook ) {
+    if ( 'post.php' !== $hook && 'post-new.php' !== $hook ) {
+        return;
+    }
+    $screen = get_current_screen();
+    if ( 'bc_template' !== $screen->post_type ) {
+        return;
+    }
+    wp_enqueue_style( 'wp-color-picker' );
+    wp_enqueue_style( 'bookcreator-admin', plugin_dir_url( __FILE__ ) . 'css/admin.css', array(), '1.0' );
+    wp_enqueue_script( 'bookcreator-admin', plugin_dir_url( __FILE__ ) . 'js/admin.js', array( 'wp-color-picker' ), '1.0', true );
+}
+add_action( 'admin_enqueue_scripts', 'bookcreator_template_admin_enqueue' );
+
 function bookcreator_save_chapter_meta( $post_id ) {
     if ( ! isset( $_POST['bookcreator_chapter_meta_nonce'] ) || ! wp_verify_nonce( $_POST['bookcreator_chapter_meta_nonce'], 'bookcreator_save_chapter_meta' ) ) {
         return;

--- a/css/admin.css
+++ b/css/admin.css
@@ -59,12 +59,11 @@
 }
 
 .bc-heading-grid {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: 20px;
 }
 
 .bc-heading-grid .bc-heading-item {
-    flex: 1 1 45%;
-    min-width: 220px;
+    min-width: 0;
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,3 @@
+jQuery(document).ready(function($){
+    $('.bc-color-field').wpColorPicker();
+});

--- a/templates/template-form.twig
+++ b/templates/template-form.twig
@@ -56,11 +56,11 @@
 </p>
 <p>
     <label for="bc_text_color">{{ text_color_label }}</label><br />
-    <input type="color" name="bc_text_color" id="bc_text_color" value="{{ text_color }}" />
+    <input type="text" class="bc-color-field" name="bc_text_color" id="bc_text_color" value="{{ text_color }}" />
 </p>
 <p>
     <label for="bc_background_color">{{ background_color_label }}</label><br />
-    <input type="color" name="bc_background_color" id="bc_background_color" value="{{ background_color }}" />
+    <input type="text" class="bc-color-field" name="bc_background_color" id="bc_background_color" value="{{ background_color }}" />
 </p>
 <p>
     <label for="bc_font_size">{{ font_size_label }}</label>
@@ -86,19 +86,30 @@
             <label for="bc_h{{ i }}_font">{{ font_label }}</label><br />
             <select name="bc_h{{ i }}_font" id="bc_h{{ i }}_font" class="widefat">
                 <option value="" {% if headings['h' ~ i].font == '' %}selected{% endif %}>Default</option>
-                <option value="Arial" {% if headings['h' ~ i].font == 'Arial' %}selected{% endif %}>Arial</option>
-                <option value="Helvetica" {% if headings['h' ~ i].font == 'Helvetica' %}selected{% endif %}>Helvetica</option>
-                <option value="Verdana" {% if headings['h' ~ i].font == 'Verdana' %}selected{% endif %}>Verdana</option>
-                <option value="Tahoma" {% if headings['h' ~ i].font == 'Tahoma' %}selected{% endif %}>Tahoma</option>
+                <optgroup label="System Serif">
+                    <option value="Times New Roman" {% if headings['h' ~ i].font == 'Times New Roman' %}selected{% endif %}>Times New Roman</option>
+                    <option value="Georgia" {% if headings['h' ~ i].font == 'Georgia' %}selected{% endif %}>Georgia</option>
+                    <option value="Garamond" {% if headings['h' ~ i].font == 'Garamond' %}selected{% endif %}>Garamond</option>
+                    <option value="Book Antiqua" {% if headings['h' ~ i].font == 'Book Antiqua' %}selected{% endif %}>Book Antiqua</option>
+                </optgroup>
+                <optgroup label="Google Serif">
+                    <option value="Source Serif Pro" {% if headings['h' ~ i].font == 'Source Serif Pro' %}selected{% endif %}>Source Serif Pro</option>
+                    <option value="Crimson Text" {% if headings['h' ~ i].font == 'Crimson Text' %}selected{% endif %}>Crimson Text</option>
+                    <option value="Libre Baskerville" {% if headings['h' ~ i].font == 'Libre Baskerville' %}selected{% endif %}>Libre Baskerville</option>
+                    <option value="PT Serif" {% if headings['h' ~ i].font == 'PT Serif' %}selected{% endif %}>PT Serif</option>
+                </optgroup>
+                <optgroup label="Monospace">
+                    <option value="Courier New" {% if headings['h' ~ i].font == 'Courier New' %}selected{% endif %}>Courier New</option>
+                </optgroup>
             </select>
         </p>
         <p>
             <label for="bc_h{{ i }}_color">{{ text_color_label }}</label><br />
-            <input type="color" name="bc_h{{ i }}_color" id="bc_h{{ i }}_color" value="{{ headings['h' ~ i].color }}" />
+            <input type="text" class="bc-color-field" name="bc_h{{ i }}_color" id="bc_h{{ i }}_color" value="{{ headings['h' ~ i].color }}" />
         </p>
         <p>
             <label for="bc_h{{ i }}_background_color">{{ background_color_label }}</label><br />
-            <input type="color" name="bc_h{{ i }}_background_color" id="bc_h{{ i }}_background_color" value="{{ headings['h' ~ i].background_color }}" />
+            <input type="text" class="bc-color-field" name="bc_h{{ i }}_background_color" id="bc_h{{ i }}_background_color" value="{{ headings['h' ~ i].background_color }}" />
         </p>
         <p>
             <label for="bc_h{{ i }}_font_size">{{ font_size_label }}</label>


### PR DESCRIPTION
## Summary
- replace HTML color inputs with WordPress color picker
- display heading style settings in two columns
- reuse Body Text font list for all heading selectors

## Testing
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0676cfd8833289eb31640bb568f0