### PR TITLE
feat: improve template layout and margin options

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -431,6 +431,10 @@ function bookcreator_meta_box_template_details( $post ) {
     $doc_width        = get_post_meta( $post->ID, 'bc_doc_width', true );
     $doc_height       = get_post_meta( $post->ID, 'bc_doc_height', true );
     $doc_unit         = get_post_meta( $post->ID, 'bc_doc_unit', true );
+    $doc_margin_top   = get_post_meta( $post->ID, 'bc_doc_margin_top', true );
+    $doc_margin_right = get_post_meta( $post->ID, 'bc_doc_margin_right', true );
+    $doc_margin_bottom= get_post_meta( $post->ID, 'bc_doc_margin_bottom', true );
+    $doc_margin_left  = get_post_meta( $post->ID, 'bc_doc_margin_left', true );
     $font_family      = get_post_meta( $post->ID, 'bc_font_family', true );
     $text_color       = get_post_meta( $post->ID, 'bc_text_color', true );
     $background_color = get_post_meta( $post->ID, 'bc_background_color', true );
@@ -458,6 +462,10 @@ function bookcreator_meta_box_template_details( $post ) {
         'landscape_label'       => esc_html__( 'Landscape', 'bookcreator' ),
         'width_label'           => esc_html__( 'Width', 'bookcreator' ),
         'height_label'          => esc_html__( 'Height', 'bookcreator' ),
+        'margin_top_label'      => esc_html__( 'Top Margin', 'bookcreator' ),
+        'margin_right_label'    => esc_html__( 'Right Margin', 'bookcreator' ),
+        'margin_bottom_label'   => esc_html__( 'Bottom Margin', 'bookcreator' ),
+        'margin_left_label'     => esc_html__( 'Left Margin', 'bookcreator' ),
         'body_text_label'       => esc_html__( 'Body Text', 'bookcreator' ),
         'font_label'            => esc_html__( 'Font', 'bookcreator' ),
         'text_color_label'      => esc_html__( 'Text Color', 'bookcreator' ),
@@ -472,6 +480,10 @@ function bookcreator_meta_box_template_details( $post ) {
         'doc_width'             => esc_attr( $doc_width ),
         'doc_height'            => esc_attr( $doc_height ),
         'doc_unit'              => esc_attr( $doc_unit ),
+        'doc_margin_top'        => esc_attr( $doc_margin_top ),
+        'doc_margin_right'      => esc_attr( $doc_margin_right ),
+        'doc_margin_bottom'     => esc_attr( $doc_margin_bottom ),
+        'doc_margin_left'       => esc_attr( $doc_margin_left ),
         'font_family'           => esc_attr( $font_family ),
         'text_color'            => esc_attr( $text_color ),
         'background_color'      => esc_attr( $background_color ),
@@ -563,6 +575,10 @@ function bookcreator_save_template_meta( $post_id ) {
         'bc_doc_width'       => 'floatval',
         'bc_doc_height'      => 'floatval',
         'bc_doc_unit'        => 'sanitize_text_field',
+        'bc_doc_margin_top'  => 'floatval',
+        'bc_doc_margin_right'=> 'floatval',
+        'bc_doc_margin_bottom'=> 'floatval',
+        'bc_doc_margin_left' => 'floatval',
         'bc_font_family'     => 'sanitize_text_field',
         'bc_text_color'      => 'sanitize_hex_color',
         'bc_background_color'=> 'sanitize_hex_color',
@@ -1148,6 +1164,10 @@ function bookcreator_render_single_template( $template ) {
                 'doc_width'       => 'bc_doc_width',
                 'doc_height'      => 'bc_doc_height',
                 'doc_unit'        => 'bc_doc_unit',
+                'doc_margin_top'  => 'bc_doc_margin_top',
+                'doc_margin_right'=> 'bc_doc_margin_right',
+                'doc_margin_bottom'=> 'bc_doc_margin_bottom',
+                'doc_margin_left' => 'bc_doc_margin_left',
                 'font_family'     => 'bc_font_family',
                 'text_color'      => 'bc_text_color',
                 'background_color'=> 'bc_background_color',

--- a/css/admin.css
+++ b/css/admin.css
@@ -67,3 +67,17 @@
 .bc-heading-grid .bc-heading-item {
     min-width: 0;
 }
+
+.bc-template-columns {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+}
+
+.bc-template-form h4 {
+    font-size: 2rem;
+}
+
+.bc-template-form h5 {
+    font-size: 1.5rem;
+}

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -32,14 +32,44 @@
         or template.h5_font or template.h5_color or template.h5_background_color or template.h5_font_size or template.h5_line_height %}
     <style>
     {% set text_unit = template.text_unit ?: 'pt' %}
+    {% set doc_unit = template.doc_unit ?: 'mm' %}
+    {% set page_unit = doc_unit %}
+    {% if template.doc_format and template.doc_format != 'Custom' %}
+        {% set sizes = {
+            'A4': [210, 297],
+            'A5': [148, 210],
+            'Letter': [216, 279]
+        } %}
+        {% set page_width = sizes[template.doc_format][0] %}
+        {% set page_height = sizes[template.doc_format][1] %}
+        {% if template.doc_orientation == 'landscape' %}
+            {% set temp = page_width %}
+            {% set page_width = page_height %}
+            {% set page_height = temp %}
+        {% endif %}
+        {% set page_unit = 'mm' %}
+    {% elseif template.doc_width and template.doc_height %}
+        {% set page_width = template.doc_width %}
+        {% set page_height = template.doc_height %}
+    {% endif %}
+    {% set has_margin = (template.doc_margin_top is not same as(null) and template.doc_margin_top is not same as('')) or
+        (template.doc_margin_right is not same as(null) and template.doc_margin_right is not same as('')) or
+        (template.doc_margin_bottom is not same as(null) and template.doc_margin_bottom is not same as('')) or
+        (template.doc_margin_left is not same as(null) and template.doc_margin_left is not same as('')) %}
     @page {
         {% if template.doc_format and template.doc_format != 'Custom' %}
         size: {{ template.doc_format }}{% if template.doc_orientation %} {{ template.doc_orientation }}{% endif %};
         {% elseif template.doc_width and template.doc_height %}
         size: {{ template.doc_width }}{{ template.doc_unit }} {{ template.doc_height }}{{ template.doc_unit }}{% if template.doc_orientation %} {{ template.doc_orientation }}{% endif %};
         {% endif %}
+        {% if has_margin %}
+        margin: {{ template.doc_margin_top|default(0) }}{{ doc_unit }} {{ template.doc_margin_right|default(0) }}{{ doc_unit }} {{ template.doc_margin_bottom|default(0) }}{{ doc_unit }} {{ template.doc_margin_left|default(0) }}{{ doc_unit }};
+        {% endif %}
     }
     body {
+        {% if page_width and page_height %}width: {{ page_width }}{{ page_unit }}; height: {{ page_height }}{{ page_unit }};{% endif %}
+        margin: 0;
+        padding: 0;
         {% if template.font_family %}font-family: '{{ template.font_family }}', serif;{% endif %}
         {% if template.font_size %}font-size: {{ template.font_size }}{{ text_unit }};{% endif %}
         {% if template.line_height %}line-height: {{ template.line_height }}{{ text_unit }};{% endif %}

--- a/templates/template-form.twig
+++ b/templates/template-form.twig
@@ -1,3 +1,4 @@
+<div class="bc-template-form">
 <p>
     <label>
         <input type="checkbox" name="bc_template_default" value="1" {% if default %}checked{% endif %} />
@@ -5,77 +6,93 @@
     </label>
 </p>
 
-<h4>{{ document_settings_label }}</h4>
-<p>
-    <label for="bc_doc_format">{{ format_label }}</label><br />
-    <select name="bc_doc_format" id="bc_doc_format" class="widefat">
-        <option value="A4" {% if doc_format == 'A4' %}selected{% endif %}>A4</option>
-        <option value="A5" {% if doc_format == 'A5' %}selected{% endif %}>A5</option>
-        <option value="Letter" {% if doc_format == 'Letter' %}selected{% endif %}>Letter</option>
-        <option value="Custom" {% if doc_format == 'Custom' %}selected{% endif %}>Custom</option>
-    </select>
-</p>
-<p>
-    <label>{{ orientation_label }}</label><br />
-    <label><input type="radio" name="bc_doc_orientation" value="portrait" {% if doc_orientation == 'portrait' %}checked{% endif %} /> {{ portrait_label }}</label>
-    <label><input type="radio" name="bc_doc_orientation" value="landscape" {% if doc_orientation == 'landscape' %}checked{% endif %} /> {{ landscape_label }}</label>
-</p>
-<p>
-    <label for="bc_doc_width">{{ width_label }}</label>
-    <input type="number" step="0.01" name="bc_doc_width" id="bc_doc_width" value="{{ doc_width }}" class="small-text" />
-    <label for="bc_doc_height">{{ height_label }}</label>
-    <input type="number" step="0.01" name="bc_doc_height" id="bc_doc_height" value="{{ doc_height }}" class="small-text" />
-    <select name="bc_doc_unit" id="bc_doc_unit">
-        <option value="mm" {% if doc_unit == 'mm' %}selected{% endif %}>mm</option>
-        <option value="cm" {% if doc_unit == 'cm' %}selected{% endif %}>cm</option>
-        <option value="inches" {% if doc_unit == 'inches' %}selected{% endif %}>inches</option>
-    </select>
-</p>
-
-<h4>{{ body_text_label }}</h4>
-<p>
-    <label for="bc_font_family">{{ font_label }}</label><br />
-    <select name="bc_font_family" id="bc_font_family" class="widefat">
-        <option value="" {% if font_family == '' %}selected{% endif %}>Default</option>
-        <optgroup label="System Serif">
-            <option value="Times New Roman" {% if font_family == 'Times New Roman' %}selected{% endif %}>Times New Roman</option>
-            <option value="Georgia" {% if font_family == 'Georgia' %}selected{% endif %}>Georgia</option>
-            <option value="Garamond" {% if font_family == 'Garamond' %}selected{% endif %}>Garamond</option>
-            <option value="Book Antiqua" {% if font_family == 'Book Antiqua' %}selected{% endif %}>Book Antiqua</option>
-        </optgroup>
-        <optgroup label="Google Serif">
-            <option value="Source Serif Pro" {% if font_family == 'Source Serif Pro' %}selected{% endif %}>Source Serif Pro</option>
-            <option value="Crimson Text" {% if font_family == 'Crimson Text' %}selected{% endif %}>Crimson Text</option>
-            <option value="Libre Baskerville" {% if font_family == 'Libre Baskerville' %}selected{% endif %}>Libre Baskerville</option>
-            <option value="PT Serif" {% if font_family == 'PT Serif' %}selected{% endif %}>PT Serif</option>
-        </optgroup>
-        <optgroup label="Monospace">
-            <option value="Courier New" {% if font_family == 'Courier New' %}selected{% endif %}>Courier New</option>
-        </optgroup>
-    </select>
-</p>
-<p>
-    <label for="bc_text_color">{{ text_color_label }}</label><br />
-    <input type="text" class="bc-color-field" name="bc_text_color" id="bc_text_color" value="{{ text_color }}" />
-</p>
-<p>
-    <label for="bc_background_color">{{ background_color_label }}</label><br />
-    <input type="text" class="bc-color-field" name="bc_background_color" id="bc_background_color" value="{{ background_color }}" />
-</p>
-<p>
-    <label for="bc_font_size">{{ font_size_label }}</label>
-    <input type="number" step="0.1" name="bc_font_size" id="bc_font_size" value="{{ font_size }}" class="small-text" />
-    <label for="bc_line_height">{{ line_height_label }}</label>
-    <input type="number" step="0.1" name="bc_line_height" id="bc_line_height" value="{{ line_height }}" class="small-text" />
-</p>
-<p>
-    <label for="bc_text_unit">{{ text_unit_label }}</label>
-    <select name="bc_text_unit" id="bc_text_unit">
-        <option value="pt" {% if text_unit == 'pt' or text_unit == '' %}selected{% endif %}>pt</option>
-        <option value="px" {% if text_unit == 'px' %}selected{% endif %}>px</option>
-        <option value="rem" {% if text_unit == 'rem' %}selected{% endif %}>rem</option>
-    </select>
-</p>
+<div class="bc-template-columns">
+    <div class="bc-document-settings">
+        <h4>{{ document_settings_label }}</h4>
+        <p>
+            <label for="bc_doc_format">{{ format_label }}</label><br />
+            <select name="bc_doc_format" id="bc_doc_format" class="widefat">
+                <option value="A4" {% if doc_format == 'A4' %}selected{% endif %}>A4</option>
+                <option value="A5" {% if doc_format == 'A5' %}selected{% endif %}>A5</option>
+                <option value="Letter" {% if doc_format == 'Letter' %}selected{% endif %}>Letter</option>
+                <option value="Custom" {% if doc_format == 'Custom' %}selected{% endif %}>Custom</option>
+            </select>
+        </p>
+        <p>
+            <label>{{ orientation_label }}</label><br />
+            <label><input type="radio" name="bc_doc_orientation" value="portrait" {% if doc_orientation == 'portrait' %}checked{% endif %} /> {{ portrait_label }}</label>
+            <label><input type="radio" name="bc_doc_orientation" value="landscape" {% if doc_orientation == 'landscape' %}checked{% endif %} /> {{ landscape_label }}</label>
+        </p>
+        <p>
+            <label for="bc_doc_width">{{ width_label }}</label>
+            <input type="number" step="0.01" name="bc_doc_width" id="bc_doc_width" value="{{ doc_width }}" class="small-text" />
+            <label for="bc_doc_height">{{ height_label }}</label>
+            <input type="number" step="0.01" name="bc_doc_height" id="bc_doc_height" value="{{ doc_height }}" class="small-text" />
+            <select name="bc_doc_unit" id="bc_doc_unit">
+                <option value="mm" {% if doc_unit == 'mm' %}selected{% endif %}>mm</option>
+                <option value="cm" {% if doc_unit == 'cm' %}selected{% endif %}>cm</option>
+                <option value="inches" {% if doc_unit == 'inches' %}selected{% endif %}>inches</option>
+            </select>
+        </p>
+        <p>
+            <label for="bc_doc_margin_top">{{ margin_top_label }}</label>
+            <input type="number" step="0.1" name="bc_doc_margin_top" id="bc_doc_margin_top" value="{{ doc_margin_top }}" class="small-text" />
+            <label for="bc_doc_margin_right">{{ margin_right_label }}</label>
+            <input type="number" step="0.1" name="bc_doc_margin_right" id="bc_doc_margin_right" value="{{ doc_margin_right }}" class="small-text" />
+            <label for="bc_doc_margin_bottom">{{ margin_bottom_label }}</label>
+            <input type="number" step="0.1" name="bc_doc_margin_bottom" id="bc_doc_margin_bottom" value="{{ doc_margin_bottom }}" class="small-text" />
+            <label for="bc_doc_margin_left">{{ margin_left_label }}</label>
+            <input type="number" step="0.1" name="bc_doc_margin_left" id="bc_doc_margin_left" value="{{ doc_margin_left }}" class="small-text" />
+        </p>
+    </div>
+    <div class="bc-body-text-settings">
+        <h4>{{ body_text_label }}</h4>
+        <p>
+            <label for="bc_font_family">{{ font_label }}</label><br />
+            <select name="bc_font_family" id="bc_font_family" class="widefat">
+                <option value="" {% if font_family == '' %}selected{% endif %}>Default</option>
+                <optgroup label="System Serif">
+                    <option value="Times New Roman" {% if font_family == 'Times New Roman' %}selected{% endif %}>Times New Roman</option>
+                    <option value="Georgia" {% if font_family == 'Georgia' %}selected{% endif %}>Georgia</option>
+                    <option value="Garamond" {% if font_family == 'Garamond' %}selected{% endif %}>Garamond</option>
+                    <option value="Book Antiqua" {% if font_family == 'Book Antiqua' %}selected{% endif %}>Book Antiqua</option>
+                </optgroup>
+                <optgroup label="Google Serif">
+                    <option value="Source Serif Pro" {% if font_family == 'Source Serif Pro' %}selected{% endif %}>Source Serif Pro</option>
+                    <option value="Crimson Text" {% if font_family == 'Crimson Text' %}selected{% endif %}>Crimson Text</option>
+                    <option value="Libre Baskerville" {% if font_family == 'Libre Baskerville' %}selected{% endif %}>Libre Baskerville</option>
+                    <option value="PT Serif" {% if font_family == 'PT Serif' %}selected{% endif %}>PT Serif</option>
+                </optgroup>
+                <optgroup label="Monospace">
+                    <option value="Courier New" {% if font_family == 'Courier New' %}selected{% endif %}>Courier New</option>
+                </optgroup>
+            </select>
+        </p>
+        <p>
+            <label for="bc_text_color">{{ text_color_label }}</label><br />
+            <input type="text" class="bc-color-field" name="bc_text_color" id="bc_text_color" value="{{ text_color }}" />
+        </p>
+        <p>
+            <label for="bc_background_color">{{ background_color_label }}</label><br />
+            <input type="text" class="bc-color-field" name="bc_background_color" id="bc_background_color" value="{{ background_color }}" />
+        </p>
+        <p>
+            <label for="bc_font_size">{{ font_size_label }}</label>
+            <input type="number" step="0.1" name="bc_font_size" id="bc_font_size" value="{{ font_size }}" class="small-text" />
+            <label for="bc_line_height">{{ line_height_label }}</label>
+            <input type="number" step="0.1" name="bc_line_height" id="bc_line_height" value="{{ line_height }}" class="small-text" />
+        </p>
+        <p>
+            <label for="bc_text_unit">{{ text_unit_label }}</label>
+            <select name="bc_text_unit" id="bc_text_unit">
+                <option value="pt" {% if text_unit == 'pt' or text_unit == '' %}selected{% endif %}>pt</option>
+                <option value="px" {% if text_unit == 'px' %}selected{% endif %}>px</option>
+                <option value="rem" {% if text_unit == 'rem' %}selected{% endif %}>rem</option>
+            </select>
+        </p>
+    </div>
+</div>
+</div>
 
 <h4>{{ heading_settings_label }}</h4>
 <div class="bc-heading-grid">
@@ -119,4 +136,5 @@
         </p>
     </div>
 {% endfor %}
+</div>
 </div>


### PR DESCRIPTION
## Summary
- arrange document settings and body text columns for clearer layout
- allow custom document margins and larger header styles in template editor
- size rendered pages and margins based on chosen document format

## Testing
- `php -l bookcreator.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68bf092951388332913fa7c914013e45