### PR TITLE
Add text alignment options for templates

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -441,6 +441,7 @@ function bookcreator_meta_box_template_details( $post ) {
     $font_size        = get_post_meta( $post->ID, 'bc_font_size', true );
     $line_height      = get_post_meta( $post->ID, 'bc_line_height', true );
     $text_unit        = get_post_meta( $post->ID, 'bc_text_unit', true );
+    $text_align       = get_post_meta( $post->ID, 'bc_text_align', true );
 
     $headings = array();
     for ( $i = 1; $i <= 5; $i++ ) {
@@ -450,6 +451,7 @@ function bookcreator_meta_box_template_details( $post ) {
             'background_color' => get_post_meta( $post->ID, 'bc_h' . $i . '_background_color', true ),
             'font_size'        => get_post_meta( $post->ID, 'bc_h' . $i . '_font_size', true ),
             'line_height'      => get_post_meta( $post->ID, 'bc_h' . $i . '_line_height', true ),
+            'align'            => get_post_meta( $post->ID, 'bc_h' . $i . '_align', true ),
         );
     }
 
@@ -473,6 +475,11 @@ function bookcreator_meta_box_template_details( $post ) {
         'font_size_label'       => esc_html__( 'Font Size', 'bookcreator' ),
         'line_height_label'     => esc_html__( 'Line Height', 'bookcreator' ),
         'text_unit_label'       => esc_html__( 'Text Unit', 'bookcreator' ),
+        'alignment_label'       => esc_html__( 'Alignment', 'bookcreator' ),
+        'align_left_label'      => esc_html__( 'Left', 'bookcreator' ),
+        'align_right_label'     => esc_html__( 'Right', 'bookcreator' ),
+        'align_center_label'    => esc_html__( 'Center', 'bookcreator' ),
+        'align_justify_label'   => esc_html__( 'Justify', 'bookcreator' ),
         'heading_settings_label'=> esc_html__( 'Heading Styles', 'bookcreator' ),
         'default'               => $default,
         'doc_format'            => esc_attr( $doc_format ),
@@ -490,6 +497,7 @@ function bookcreator_meta_box_template_details( $post ) {
         'font_size'             => esc_attr( $font_size ),
         'line_height'           => esc_attr( $line_height ),
         'text_unit'             => esc_attr( $text_unit ),
+        'text_align'            => esc_attr( $text_align ),
         'headings'              => $headings,
     ) );
 }
@@ -585,6 +593,7 @@ function bookcreator_save_template_meta( $post_id ) {
         'bc_font_size'       => 'sanitize_text_field',
         'bc_line_height'     => 'sanitize_text_field',
         'bc_text_unit'       => 'sanitize_text_field',
+        'bc_text_align'      => 'sanitize_text_field',
     );
 
     for ( $i = 1; $i <= 5; $i++ ) {
@@ -593,6 +602,7 @@ function bookcreator_save_template_meta( $post_id ) {
         $fields[ 'bc_h' . $i . '_background_color' ] = 'sanitize_hex_color';
         $fields[ 'bc_h' . $i . '_font_size' ]        = 'sanitize_text_field';
         $fields[ 'bc_h' . $i . '_line_height' ]      = 'sanitize_text_field';
+        $fields[ 'bc_h' . $i . '_align' ]            = 'sanitize_text_field';
     }
 
     foreach ( $fields as $field => $sanitize ) {
@@ -1174,6 +1184,7 @@ function bookcreator_render_single_template( $template ) {
                 'font_size'       => 'bc_font_size',
                 'line_height'     => 'bc_line_height',
                 'text_unit'       => 'bc_text_unit',
+                'text_align'      => 'bc_text_align',
             );
 
             for ( $i = 1; $i <= 5; $i++ ) {
@@ -1182,6 +1193,7 @@ function bookcreator_render_single_template( $template ) {
                 $template_fields[ 'h' . $i . '_background_color' ] = 'bc_h' . $i . '_background_color';
                 $template_fields[ 'h' . $i . '_font_size' ]        = 'bc_h' . $i . '_font_size';
                 $template_fields[ 'h' . $i . '_line_height' ]      = 'bc_h' . $i . '_line_height';
+                $template_fields[ 'h' . $i . '_align' ]            = 'bc_h' . $i . '_align';
             }
 
             foreach ( $template_fields as $key => $meta_key ) {

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -75,6 +75,7 @@
         {% if template.line_height %}line-height: {{ template.line_height }}{{ text_unit }};{% endif %}
         {% if template.text_color %}color: {{ template.text_color }};{% endif %}
         {% if template.background_color %}background-color: {{ template.background_color }};{% endif %}
+        {% if template.text_align %}text-align: {{ template.text_align }};{% endif %}
     }
     {% for i in 1..5 %}
     h{{ i }} {
@@ -88,6 +89,8 @@
         {% if hfs %}font-size: {{ hfs }}{{ text_unit }};{% endif %}
         {% set hlh = attribute(template, 'h' ~ i ~ '_line_height') %}
         {% if hlh %}line-height: {{ hlh }}{{ text_unit }};{% endif %}
+        {% set ha = attribute(template, 'h' ~ i ~ '_align') %}
+        {% if ha %}text-align: {{ ha }};{% endif %}
     }
     {% endfor %}
     code, pre {

--- a/templates/template-form.twig
+++ b/templates/template-form.twig
@@ -41,6 +41,7 @@
             <input type="number" step="0.1" name="bc_doc_margin_right" id="bc_doc_margin_right" value="{{ doc_margin_right }}" class="small-text" />
             <label for="bc_doc_margin_bottom">{{ margin_bottom_label }}</label>
             <input type="number" step="0.1" name="bc_doc_margin_bottom" id="bc_doc_margin_bottom" value="{{ doc_margin_bottom }}" class="small-text" />
+            <br />
             <label for="bc_doc_margin_left">{{ margin_left_label }}</label>
             <input type="number" step="0.1" name="bc_doc_margin_left" id="bc_doc_margin_left" value="{{ doc_margin_left }}" class="small-text" />
         </p>
@@ -90,6 +91,16 @@
                 <option value="rem" {% if text_unit == 'rem' %}selected{% endif %}>rem</option>
             </select>
         </p>
+        <p>
+            <label for="bc_text_align">{{ alignment_label }}</label><br />
+            <select name="bc_text_align" id="bc_text_align" class="widefat">
+                <option value="" {% if text_align == '' %}selected{% endif %}>Default</option>
+                <option value="left" {% if text_align == 'left' %}selected{% endif %}>{{ align_left_label }}</option>
+                <option value="right" {% if text_align == 'right' %}selected{% endif %}>{{ align_right_label }}</option>
+                <option value="center" {% if text_align == 'center' %}selected{% endif %}>{{ align_center_label }}</option>
+                <option value="justify" {% if text_align == 'justify' %}selected{% endif %}>{{ align_justify_label }}</option>
+            </select>
+        </p>
     </div>
 </div>
 </div>
@@ -133,6 +144,16 @@
             <input type="number" step="0.1" name="bc_h{{ i }}_font_size" id="bc_h{{ i }}_font_size" value="{{ headings['h' ~ i].font_size }}" class="small-text" />
             <label for="bc_h{{ i }}_line_height">{{ line_height_label }}</label>
             <input type="number" step="0.1" name="bc_h{{ i }}_line_height" id="bc_h{{ i }}_line_height" value="{{ headings['h' ~ i].line_height }}" class="small-text" />
+        </p>
+        <p>
+            <label for="bc_h{{ i }}_align">{{ alignment_label }}</label><br />
+            <select name="bc_h{{ i }}_align" id="bc_h{{ i }}_align" class="widefat">
+                <option value="" {% if headings['h' ~ i].align == '' %}selected{% endif %}>Default</option>
+                <option value="left" {% if headings['h' ~ i].align == 'left' %}selected{% endif %}>{{ align_left_label }}</option>
+                <option value="right" {% if headings['h' ~ i].align == 'right' %}selected{% endif %}>{{ align_right_label }}</option>
+                <option value="center" {% if headings['h' ~ i].align == 'center' %}selected{% endif %}>{{ align_center_label }}</option>
+                <option value="justify" {% if headings['h' ~ i].align == 'justify' %}selected{% endif %}>{{ align_justify_label }}</option>
+            </select>
         </p>
     </div>
 {% endfor %}


### PR DESCRIPTION
## Summary
- allow template authors to choose text alignment (left, right, center, justify) for body text and headings
- support new alignment settings in template rendering
- improve document settings layout by breaking left margin onto new line

## Testing
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c93d3108332962ea81779255e10