### PR TITLE
Fix heading alignment override from JS attribute

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,3 +21,9 @@ body {
 .chapter {
   margin-top: 2rem;
 }
+
+/* Prevent JS framework alignment attributes from overriding heading styles */
+h1, h2, h3, h4, h5,
+h1[data-align-last-split-element], h2[data-align-last-split-element], h3[data-align-last-split-element], h4[data-align-last-split-element], h5[data-align-last-split-element] {
+  text-align: initial;
+}

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -78,7 +78,7 @@
         {% if template.text_align %}text-align: {{ template.text_align }};{% endif %}
     }
     {% for i in 1..5 %}
-    h{{ i }} {
+    h{{ i }}, h{{ i }}[data-align-last-split-element] {
         {% set hf = attribute(template, 'h' ~ i ~ '_font') %}
         {% if hf %}font-family: '{{ hf }}', sans-serif;{% endif %}
         {% set hc = attribute(template, 'h' ~ i ~ '_color') %}


### PR DESCRIPTION
## Summary
- Ensure heading styles apply even when `data-align-last-split-element` is present
- Add base CSS to prevent JS alignment attribute from overriding heading styles

## Testing
- `composer validate --no-check-all --strict`
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0f492c248332a2a2a9d0ba394d96