### PR TITLE
Fix body font selection and add optional page border

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -442,6 +442,7 @@ function bookcreator_meta_box_template_details( $post ) {
     $line_height      = get_post_meta( $post->ID, 'bc_line_height', true );
     $text_unit        = get_post_meta( $post->ID, 'bc_text_unit', true );
     $text_align       = get_post_meta( $post->ID, 'bc_text_align', true );
+    $show_border      = get_post_meta( $post->ID, 'bc_show_border', true );
 
     $headings = array();
     for ( $i = 1; $i <= 5; $i++ ) {
@@ -480,6 +481,7 @@ function bookcreator_meta_box_template_details( $post ) {
         'align_right_label'     => esc_html__( 'Right', 'bookcreator' ),
         'align_center_label'    => esc_html__( 'Center', 'bookcreator' ),
         'align_justify_label'   => esc_html__( 'Justify', 'bookcreator' ),
+        'border_label'          => esc_html__( 'Show Page Border', 'bookcreator' ),
         'heading_settings_label'=> esc_html__( 'Heading Styles', 'bookcreator' ),
         'default'               => $default,
         'doc_format'            => esc_attr( $doc_format ),
@@ -498,6 +500,7 @@ function bookcreator_meta_box_template_details( $post ) {
         'line_height'           => esc_attr( $line_height ),
         'text_unit'             => esc_attr( $text_unit ),
         'text_align'            => esc_attr( $text_align ),
+        'show_border'           => esc_attr( $show_border ),
         'headings'              => $headings,
     ) );
 }
@@ -594,6 +597,7 @@ function bookcreator_save_template_meta( $post_id ) {
         'bc_line_height'     => 'sanitize_text_field',
         'bc_text_unit'       => 'sanitize_text_field',
         'bc_text_align'      => 'sanitize_text_field',
+        'bc_show_border'     => 'sanitize_text_field',
     );
 
     for ( $i = 1; $i <= 5; $i++ ) {
@@ -1185,6 +1189,7 @@ function bookcreator_render_single_template( $template ) {
                 'line_height'     => 'bc_line_height',
                 'text_unit'       => 'bc_text_unit',
                 'text_align'      => 'bc_text_align',
+                'show_border'     => 'bc_show_border',
             );
 
             for ( $i = 1; $i <= 5; $i++ ) {

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -70,12 +70,13 @@
         {% if page_width and page_height %}width: {{ page_width }}{{ page_unit }}; height: {{ page_height }}{{ page_unit }};{% endif %}
         margin: 0;
         padding: 0;
-        {% if template.font_family %}font-family: '{{ template.font_family }}', serif;{% endif %}
+        {% if template.font_family %}font-family: '{{ template.font_family }}', serif !important;{% endif %}
         {% if template.font_size %}font-size: {{ template.font_size }}{{ text_unit }};{% endif %}
         {% if template.line_height %}line-height: {{ template.line_height }}{{ text_unit }};{% endif %}
         {% if template.text_color %}color: {{ template.text_color }};{% endif %}
         {% if template.background_color %}background-color: {{ template.background_color }};{% endif %}
         {% if template.text_align %}text-align: {{ template.text_align }};{% endif %}
+        {% if template.show_border %}border: 1px solid #ccc; box-sizing: border-box;{% endif %}
     }
     {% for i in 1..5 %}
     h{{ i }}, h{{ i }}[data-align-last-split-element] {

--- a/templates/template-form.twig
+++ b/templates/template-form.twig
@@ -63,6 +63,12 @@
             <label for="bc_doc_margin_left">{{ margin_left_label }}</label>
             <input type="number" step="0.1" name="bc_doc_margin_left" id="bc_doc_margin_left" value="{{ doc_margin_left }}" class="small-text" />
         </p>
+        <p>
+            <label>
+                <input type="checkbox" name="bc_show_border" value="1" {% if show_border == '1' %}checked{% endif %} />
+                {{ border_label }}
+            </label>
+        </p>
     </div>
     <div class="bc-body-text-settings">
         <h4>{{ body_text_label }}</h4>


### PR DESCRIPTION
## Summary
- ensure body font selection applies by forcing font-family override
- add template option to toggle a gray page border for layout debugging

## Testing
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0370c26408332b4d42ceff156a12d