### PR TITLE
Add optional cover display with zero-margin cover page

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -285,6 +285,10 @@ function bookcreator_meta_box_descriptive( $post ) {
 function bookcreator_meta_box_prelim( $post ) {
     $cover_id       = get_post_meta( $post->ID, 'bc_cover', true );
     $retina_id      = get_post_meta( $post->ID, 'bc_retina_cover', true );
+    $show_cover     = get_post_meta( $post->ID, 'bc_show_cover', true );
+    if ( '' === $show_cover ) {
+        $show_cover = '1';
+    }
     ?>
     <p><label for="bc_cover"><?php esc_html_e( 'Copertina', 'bookcreator' ); ?></label><br/>
     <input type="file" name="bc_cover" id="bc_cover" /><br/>
@@ -293,6 +297,14 @@ function bookcreator_meta_box_prelim( $post ) {
     <p><label for="bc_retina_cover"><?php esc_html_e( 'Copertina Retina Display', 'bookcreator' ); ?></label><br/>
     <input type="file" name="bc_retina_cover" id="bc_retina_cover" /><br/>
     <?php if ( $retina_id ) { echo wp_get_attachment_image( $retina_id, array( 100, 100 ) ); } ?></p>
+
+    <p>
+        <input type="hidden" name="bc_show_cover" value="0" />
+        <label>
+            <input type="checkbox" name="bc_show_cover" id="bc_show_cover" value="1" <?php checked( $show_cover, '1' ); ?> />
+            <?php esc_html_e( 'Mostra copertina', 'bookcreator' ); ?>
+        </label>
+    </p>
 
     <p><label for="bc_frontispiece"><?php esc_html_e( 'Frontespizio', 'bookcreator' ); ?></label></p>
     <?php
@@ -535,6 +547,7 @@ function bookcreator_save_meta( $post_id ) {
         'bc_copyright'     => 'wp_kses_post',
         'bc_dedication'    => 'wp_kses_post',
         'bc_preface'       => 'wp_kses_post',
+        'bc_show_cover'    => 'absint',
         'bc_appendix'      => 'wp_kses_post',
         'bc_bibliography'  => 'wp_kses_post',
         'bc_author_note'   => 'wp_kses_post',
@@ -1150,6 +1163,7 @@ function bookcreator_render_single_template( $template ) {
             'audience'     => get_post_meta( $post_id, 'bc_audience', true ),
             'cover'        => wp_get_attachment_url( get_post_meta( $post_id, 'bc_cover', true ) ),
             'retina_cover' => wp_get_attachment_url( get_post_meta( $post_id, 'bc_retina_cover', true ) ),
+            'show_cover'   => (bool) get_post_meta( $post_id, 'bc_show_cover', true ),
             'frontispiece' => get_post_meta( $post_id, 'bc_frontispiece', true ),
             'copyright'    => get_post_meta( $post_id, 'bc_copyright', true ),
             'dedication'   => get_post_meta( $post_id, 'bc_dedication', true ),

--- a/css/paged.css
+++ b/css/paged.css
@@ -4,6 +4,10 @@
   margin: 2cm;
 }
 
+@page cover {
+  margin: 0;
+}
+
 @page :left {
   @top-left { content: string(bookTitle); }
   @bottom-left { content: counter(page); }
@@ -26,6 +30,7 @@
 
 .cover {
   break-after: page;
+  page: cover;
 }
 
 .title-page {

--- a/templates/book.twig
+++ b/templates/book.twig
@@ -106,7 +106,7 @@
     {% endif %}
  </head>
  <body>
- {% if book.cover %}<img src="{{ book.cover }}" alt="Cover" class="cover" />{% endif %}
+ {% if book.cover and book.show_cover %}<img src="{{ book.cover }}" alt="Cover" class="cover" />{% endif %}
  <div class="title-page">
      {% if book.author %}<p class="author">{{ book.author }}</p>{% endif %}
      {% if book.coauthors %}<p class="coauthors">{{ book.coauthors }}</p>{% endif %}


### PR DESCRIPTION
## Summary
- allow toggling cover image visibility with a new checkbox
- render cover page with zero margins when displayed
- pass cover visibility setting to book template

## Testing
- `php -l bookcreator.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c041cbc2e483329bd984878c8040fa