### PR TITLE
Add PDF export to BookCreator

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,3 +1,22 @@
 jQuery(document).ready(function($){
     $('.bc-color-field').wpColorPicker();
+
+    $('#bc-generate-pdf').on('click', function(){
+        var postId = $(this).data('post');
+        var nonce = $('#bookcreator_generate_pdf_nonce').val();
+        var button = $(this);
+        button.prop('disabled', true);
+        $.post(ajaxurl, {
+            action: 'bookcreator_generate_pdf',
+            post_id: postId,
+            nonce: nonce
+        }, function(response){
+            button.prop('disabled', false);
+            if(response.success){
+                $('#bc-pdf-link').attr('href', response.data.url).text(response.data.label).show();
+            } else if(response.data){
+                alert(response.data);
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- add side meta box with button to generate PDF
- build book HTML for rendering and PDF generation
- implement AJAX handler using pagedjs-cli and expose link to generated PDF
- add admin JS to trigger PDF generation and display download link

## Testing
- `php -l bookcreator.php`
- `node --check js/admin.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04ad123f08332b855b7ea2538640c