### PR TITLE
Fix Generate PDF button by loading admin script on book posts

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -658,19 +658,19 @@ function bookcreator_save_template_meta( $post_id ) {
 }
 add_action( 'save_post_bc_template', 'bookcreator_save_template_meta' );
 
-function bookcreator_template_admin_enqueue( $hook ) {
+function bookcreator_admin_enqueue( $hook ) {
     if ( 'post.php' !== $hook && 'post-new.php' !== $hook ) {
         return;
     }
     $screen = get_current_screen();
-    if ( 'bc_template' !== $screen->post_type ) {
+    if ( ! in_array( $screen->post_type, array( 'bc_template', 'book_creator' ), true ) ) {
         return;
     }
     wp_enqueue_style( 'wp-color-picker' );
     wp_enqueue_style( 'bookcreator-admin', plugin_dir_url( __FILE__ ) . 'css/admin.css', array(), '1.0' );
     wp_enqueue_script( 'bookcreator-admin', plugin_dir_url( __FILE__ ) . 'js/admin.js', array( 'wp-color-picker' ), '1.0', true );
 }
-add_action( 'admin_enqueue_scripts', 'bookcreator_template_admin_enqueue' );
+add_action( 'admin_enqueue_scripts', 'bookcreator_admin_enqueue' );
 
 function bookcreator_save_chapter_meta( $post_id ) {
     if ( ! isset( $_POST['bookcreator_chapter_meta_nonce'] ) || ! wp_verify_nonce( $_POST['bookcreator_chapter_meta_nonce'], 'bookcreator_save_chapter_meta' ) ) {


### PR DESCRIPTION
## Summary
- Load `admin.js` on `book_creator` and `bc_template` post edit screens so the **Generate PDF** button triggers PDF creation

## Testing
- `php -l bookcreator.php`


------
https://chatgpt.com/codex/tasks/task_e_68c04d5bce7083329e8a77b46149d491