### PR TITLE
Improve feedback after PDF generation

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -3,20 +3,34 @@ jQuery(document).ready(function($){
 
     $('#bc-generate-pdf').on('click', function(){
         var postId = $(this).data('post');
-        var nonce = $('#bookcreator_generate_pdf_nonce').val();
+        var nonce  = $('#bookcreator_generate_pdf_nonce').val();
         var button = $(this);
         button.prop('disabled', true);
-        $.post(ajaxurl, {
-            action: 'bookcreator_generate_pdf',
-            post_id: postId,
-            nonce: nonce
-        }, function(response){
-            button.prop('disabled', false);
-            if(response.success){
-                $('#bc-pdf-link').attr('href', response.data.url).text(response.data.label).show();
-            } else if(response.data){
-                alert(response.data);
+
+        $.ajax({
+            url: ajaxurl,
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                action: 'bookcreator_generate_pdf',
+                post_id: postId,
+                nonce: nonce
             }
+        })
+        .done(function(response){
+            if (response && response.success) {
+                $('#bc-pdf-link').attr('href', response.data.url).text(response.data.label).show();
+            } else if (response && response.data) {
+                alert(response.data);
+            } else {
+                alert('Unexpected server response.');
+            }
+        })
+        .fail(function(){
+            alert('PDF generation failed.');
+        })
+        .always(function(){
+            button.prop('disabled', false);
         });
     });
 });


### PR DESCRIPTION
## Summary
- Use $.ajax for generating PDFs with explicit JSON handling
- Re-enable the Generate PDF button and show errors when the request fails

## Testing
- `node --check js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68c04f8a18808332b242e8fc1f68d180