### PR TITLE
Fix EPUB document markup for readers

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -1178,14 +1178,20 @@ function bookcreator_prepare_epub_content( $content ) {
     return $filtered;
 }
 
-function bookcreator_build_epub_document( $title, $body ) {
+function bookcreator_build_epub_document( $title, $body, $language = '' ) {
+    if ( ! $language ) {
+        $language = 'en';
+    }
+
+    $language = strtolower( str_replace( '_', '-', $language ) );
+    $lang_attr = bookcreator_escape_xml( $language );
+
     $document  = '<?xml version="1.0" encoding="utf-8"?>\n';
-    $document .= '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"\n';
-    $document .= '    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">\n';
-    $document .= '<html xmlns="http://www.w3.org/1999/xhtml">\n';
+    $document .= '<!DOCTYPE html>\n';
+    $document .= '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="' . $lang_attr . '" lang="' . $lang_attr . '">\n';
     $document .= '<head>\n';
-    $document .= '<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />\n';
-    $document .= '<title>' . esc_html( $title ) . '</title>\n';
+    $document .= '<meta charset="utf-8" />\n';
+    $document .= '<title>' . bookcreator_escape_xml( $title ) . '</title>\n';
     $document .= '<link rel="stylesheet" type="text/css" href="styles/bookcreator.css" />\n';
     $document .= '</head>\n';
     $document .= '<body>\n';
@@ -1347,7 +1353,7 @@ function bookcreator_process_epub_images( $html, array &$assets, array &$asset_m
     );
 }
 
-function bookcreator_build_nav_document( $book_title, $chapters ) {
+function bookcreator_build_nav_document( $book_title, $chapters, $language = '' ) {
     $title   = bookcreator_escape_xml( sprintf( __( 'Indice - %s', 'bookcreator' ), $book_title ) );
     $heading = bookcreator_escape_xml( __( 'Indice', 'bookcreator' ) );
 
@@ -1356,16 +1362,21 @@ function bookcreator_build_nav_document( $book_title, $chapters ) {
         $items[] = '<li><a href="' . bookcreator_escape_xml( $chapter['filename'] ) . '">' . bookcreator_escape_xml( $chapter['title'] ) . '</a></li>';
     }
 
-    $items_html = implode( "
-", $items );
+    $items_html = implode( "\n", $items );
+
+    if ( ! $language ) {
+        $language = 'en';
+    }
+
+    $language  = strtolower( str_replace( '_', '-', $language ) );
+    $lang_attr = bookcreator_escape_xml( $language );
 
     $doc = <<<NAV
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="{$lang_attr}" lang="{$lang_attr}">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta charset="utf-8" />
 <title>{$title}</title>
 <link rel="stylesheet" type="text/css" href="styles/bookcreator.css" />
 </head>
@@ -1558,7 +1569,7 @@ XML;
                 'id'       => 'cover',
                 'title'    => __( 'Copertina', 'bookcreator' ),
                 'filename' => 'cover.xhtml',
-                'content'  => bookcreator_build_epub_document( __( 'Copertina', 'bookcreator' ), $cover_body ),
+                'content'  => bookcreator_build_epub_document( __( 'Copertina', 'bookcreator' ), $cover_body, $language ),
             );
         }
     }
@@ -1649,7 +1660,7 @@ XML;
         'id'       => 'front-matter',
         'title'    => __( 'Dettagli del libro', 'bookcreator' ),
         'filename' => 'front-matter.xhtml',
-        'content'  => bookcreator_build_epub_document( __( 'Dettagli del libro', 'bookcreator' ), $body ),
+        'content'  => bookcreator_build_epub_document( __( 'Dettagli del libro', 'bookcreator' ), $body, $language ),
     );
 
     $chapters_posts = bookcreator_get_ordered_chapters_for_book( $book_id );
@@ -1704,12 +1715,12 @@ XML;
                 'id'       => 'chapter-' . ( $index + 1 ),
                 'title'    => $chapter_title,
                 'filename' => $file_slug,
-                'content'  => bookcreator_build_epub_document( $chapter_title, $chapter_body ),
+                'content'  => bookcreator_build_epub_document( $chapter_title, $chapter_body, $language ),
             );
         }
     }
 
-    $nav_document = bookcreator_build_nav_document( $title, $chapters );
+    $nav_document = bookcreator_build_nav_document( $title, $chapters, $language );
 
     if ( false === file_put_contents( $oebps_dir . '/nav.xhtml', $nav_document ) ) {
         bookcreator_delete_directory( $temp_dir );


### PR DESCRIPTION
## Summary
- output EPUB content documents using HTML5-compatible markup and language attributes so readers render sections correctly
- align the navigation document with the new markup and share the computed book language across generated files

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68cfcd789be88332afa366adff5b846c