### PR TITLE
Include nav document in EPUB spine

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -1831,6 +1831,7 @@ XML;
 
     $opf .= "  </manifest>\n";
     $opf .= "  <spine>\n";
+    $opf .= "    <itemref idref=\"nav\" />\n";
     foreach ( $chapters as $chapter ) {
         $opf .= '    <itemref idref="' . bookcreator_escape_xml( $chapter['id'] ) . '" />\n';
     }


### PR DESCRIPTION
## Summary
- ensure the generated table of contents (nav.xhtml) is included in the EPUB spine so it appears inside the book

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfe79b7c908332884f7434303dd485