### PR TITLE
Add template management for ePub generation

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -81,3 +81,16 @@
 .bc-template-form h5 {
     font-size: 1.5rem;
 }
+
+.bookcreator-color-sample {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 1px solid #ccc;
+    margin-right: 8px;
+    vertical-align: middle;
+}
+
+.bookcreator-template-select {
+    margin-bottom: 8px;
+}

--- a/js/templates.js
+++ b/js/templates.js
@@ -1,0 +1,3 @@
+jQuery( function ( $ ) {
+    $( '.bookcreator-color-field' ).wpColorPicker();
+} );


### PR DESCRIPTION
## Summary
- add an admin page to create, edit, and delete book templates with customizable title colors
- allow selecting a template when generating ePub files and remember the last used choice per book
- apply the chosen template style when building the ePub so the book title color reflects the template settings

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68cff3d076fc8332a9663494eab45527