### PR TITLE
Ensure cover precedes index in generated EPUBs

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -2026,6 +2026,7 @@ XML;
             $copyright_body .= '</section>';
         }
 
+        $copyright_body .= '</div>';
         $copyright_body  = bookcreator_process_epub_images( $copyright_body, $assets, $asset_map );
 
         $chapters[] = array(
@@ -2300,8 +2301,18 @@ XML;
 
     $opf .= "  </manifest>\n";
     $opf .= "  <spine>\n";
-    $opf .= "    <itemref idref=\"nav\" />\n";
-    foreach ( $chapters as $chapter ) {
+
+    $start_index = 0;
+    if ( ! empty( $chapters ) && 'cover' === $chapters[0]['id'] ) {
+        $opf .= '    <itemref idref="' . bookcreator_escape_xml( $chapters[0]['id'] ) . '" />\n';
+        $start_index = 1;
+    }
+
+    $opf .= "    <itemref idref=\"nav\" linear=\"no\" />\n";
+
+    $chapters_count = count( $chapters );
+    for ( $i = $start_index; $i < $chapters_count; $i++ ) {
+        $chapter = $chapters[ $i ];
         $opf .= '    <itemref idref="' . bookcreator_escape_xml( $chapter['id'] ) . '" />\n';
     }
     $opf .= "  </spine>\n";


### PR DESCRIPTION
## Summary
- close the copyright section markup before processing images to avoid malformed XHTML output
- adjust the OPF spine so the cover page precedes the navigation document and mark the TOC as non-linear

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68cfff2f329c833298e6ed322a1236e7