### PR TITLE
Remove description heading from EPUB frontispiece

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -1924,7 +1924,7 @@ XML;
     }
 
     if ( $description_meta ) {
-        $frontispiece_body .= '<section class="bookcreator-frontispiece__description"><h2>' . esc_html__( 'Descrizione', 'bookcreator' ) . '</h2>';
+        $frontispiece_body .= '<section class="bookcreator-frontispiece__description">';
         $frontispiece_body .= bookcreator_prepare_epub_content( $description_meta );
         $frontispiece_body .= '</section>';
     }


### PR DESCRIPTION
## Summary
- remove the "Descrizione" heading from the EPUB frontispiece description section so the description content appears without a title

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d00ede2a90833287b8c544675ce0eb