### PR TITLE
Remove edition metadata from EPUB output

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -1966,14 +1966,6 @@ XML;
         );
     }
 
-    $edition = get_post_meta( $book_id, 'bc_edition', true );
-    if ( $edition ) {
-        $copyright_items[] = array(
-            'label' => __( 'Edizione/Versione', 'bookcreator' ),
-            'value' => $edition,
-        );
-    }
-
     $legal_notice = get_post_meta( $book_id, 'bc_copyright', true );
 
     if ( $copyright_items || $legal_notice ) {


### PR DESCRIPTION
## Summary
- stop adding the Edizione/Versione field to the copyright metadata when building the EPUB export

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d0267164348332b7eaa5f845f810cd