### PR TITLE
Add configurable template types for EPUB and PDF

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -94,3 +94,23 @@
 .bookcreator-template-select {
     margin-bottom: 8px;
 }
+
+.bookcreator-template-select label {
+    font-weight: 600;
+    display: block;
+    margin-bottom: 4px;
+}
+
+.bookcreator-template-select-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.bookcreator-template-settings {
+    margin-top: 20px;
+}
+
+.bookcreator-template-settings h2 {
+    margin-top: 0;
+}

--- a/js/templates.js
+++ b/js/templates.js
@@ -1,3 +1,18 @@
 jQuery( function ( $ ) {
     $( '.bookcreator-color-field' ).wpColorPicker();
+
+    var $typeField = $( '#bookcreator_template_type' );
+    if ( $typeField.length ) {
+        var toggleTemplateSettings = function () {
+            var currentType = $typeField.val();
+            $( '.bookcreator-template-settings' ).each( function () {
+                var $section = $( this );
+                var matches = $section.data( 'template-type' ) === currentType;
+                $section.toggle( matches );
+            } );
+        };
+
+        $typeField.on( 'change', toggleTemplateSettings );
+        toggleTemplateSettings();
+    }
 } );


### PR DESCRIPTION
## Summary
- introduce template type configuration with dedicated EPUB and PDF settings and validation during export
- refresh the admin template management UI to handle type-specific fields and show summaries per format
- split template selection for EPUB/PDF exports and update related styling and scripts

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d04c9f2f7483328ac02e36c1a1ab2e