### PR TITLE
Add ePub book title style controls

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -114,3 +114,29 @@
 .bookcreator-template-settings h2 {
     margin-top: 0;
 }
+
+.bookcreator-style-grid {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    align-items: start;
+}
+
+.bookcreator-style-grid__item label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.bookcreator-style-grid__item input[type="text"],
+.bookcreator-style-grid__item select {
+    width: 100%;
+}
+
+.bookcreator-style-grid__item .wp-picker-container {
+    width: 100%;
+}
+
+.bookcreator-style-grid__item .wp-color-result {
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- add reusable defaults and font family options for ePub title styling
- extend the ePub template settings UI with grouped controls for book title typography, spacing, and color
- apply saved title styling when generating ePub CSS, including Google Font imports when needed

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d12dad38648332b27f936b7b641975