### PR TITLE
Add layout and alignment controls to book title style settings

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -117,12 +117,26 @@
 
 .bookcreator-style-grid {
     display: grid;
-    gap: 12px;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 24px;
+}
+
+.bookcreator-style-grid--two-columns {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     align-items: start;
 }
 
+.bookcreator-style-grid__column {
+    display: grid;
+    gap: 12px;
+}
+
 .bookcreator-style-grid__item label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.bookcreator-style-grid__group-title {
     display: block;
     font-weight: 600;
     margin-bottom: 4px;
@@ -138,5 +152,21 @@
 }
 
 .bookcreator-style-grid__item .wp-color-result {
+    width: 100%;
+}
+
+.bookcreator-style-split {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.bookcreator-style-split__field {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.bookcreator-style-split__field input[type="text"] {
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- add helpers to handle CSS box values and extend book title defaults with alignment and per-side spacing settings
- update the template configuration form to provide alignment and individual margin/padding inputs arranged in two columns
- adjust generated ePub styles and admin CSS to apply the new alignment and layout controls

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d1348ccfdc8332a4572d5143575492