### PR TITLE
Remove Google Fonts and add ePub hyphenation options

### DIFF
--- a/templates/single-book_creator.php
+++ b/templates/single-book_creator.php
@@ -15,6 +15,7 @@ $meta_fields = array(
     'bc_isbn'         => __( 'ISBN', 'bookcreator' ),
     'bc_pub_date'     => __( 'Data di pubblicazione', 'bookcreator' ),
     'bc_edition'      => __( 'Edizione/Versione', 'bookcreator' ),
+    'bc_language'     => __( 'Lingua', 'bookcreator' ),
 );
 
 $rich_text_fields = array(
@@ -96,6 +97,8 @@ get_header();
 
                     if ( 'bc_pub_date' === $field_key ) {
                         $value = date_i18n( get_option( 'date_format' ), strtotime( $value ) );
+                    } elseif ( 'bc_language' === $field_key && function_exists( 'bookcreator_get_language_label' ) ) {
+                        $value = bookcreator_get_language_label( $value );
                     }
                     ?>
                     <?php if ( 'bc_publisher' === $field_key ) : ?>


### PR DESCRIPTION
## Summary
- drop Google Fonts imports from the ePub template font list
- add a selectable hyphenation mode for ePub templates and apply it in generated styles
- expose the book language metadata across admin columns, front-end output, and generated ePub/PDF frontispieces

## Testing
- php -l bookcreator.php
- php -l templates/single-book_creator.php

------
https://chatgpt.com/codex/tasks/task_e_68d14824ce4c83329918314398f57cd8