### PR TITLE
Refine title hyphenation and paragraph featured images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,3 +27,14 @@ h1, h2, h3, h4, h5,
 h1[data-align-last-split-element], h2[data-align-last-split-element], h3[data-align-last-split-element], h4[data-align-last-split-element], h5[data-align-last-split-element] {
   text-align: initial;
 }
+
+.bookcreator-paragraph__featured-image {
+  margin: 1.5rem 0;
+}
+
+.bookcreator-paragraph__featured-image img,
+.bookcreator-paragraph__featured-image-img {
+  width: 100%;
+  height: auto;
+  display: block;
+}

--- a/templates/single-book_creator.php
+++ b/templates/single-book_creator.php
@@ -198,6 +198,19 @@ get_header();
                                     ?>
                                     <article id="paragraph-<?php echo esc_attr( $paragraph->ID ); ?>" class="bookcreator-paragraph">
                                         <h3 class="bookcreator-paragraph__title"><?php echo esc_html( $paragraph_data['number'] . ' ' . get_the_title( $paragraph ) ); ?></h3>
+                                        <?php
+                                        $paragraph_thumbnail_id = get_post_thumbnail_id( $paragraph );
+                                        if ( $paragraph_thumbnail_id ) :
+                                            $paragraph_thumbnail_html = wp_get_attachment_image( $paragraph_thumbnail_id, 'full', false, array( 'class' => 'bookcreator-paragraph__featured-image-img' ) );
+                                            if ( $paragraph_thumbnail_html ) :
+                                                ?>
+                                                <figure class="bookcreator-paragraph__featured-image">
+                                                    <?php echo $paragraph_thumbnail_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                                </figure>
+                                                <?php
+                                            endif;
+                                        endif;
+                                        ?>
                                         <div class="bookcreator-paragraph__content">
                                             <?php echo apply_filters( 'the_content', $paragraph->post_content ); ?>
                                         </div>


### PR DESCRIPTION
## Summary
- embed the hyphenation control inside the book title style configuration and update normalization to drop the global setting
- scope hyphenation CSS to the frontispiece title and add styling support for paragraph featured images in the generated EPUB
- render paragraph featured images after titles on the public template with matching responsive styles

## Testing
- php -l bookcreator.php
- php -l templates/single-book_creator.php

------
https://chatgpt.com/codex/tasks/task_e_68d14c3a7a088332a36386f93ea38bd5