### PR TITLE
Add Claude connection test button in settings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,52 @@
+(function ($) {
+    function updateStatus($status, message, type) {
+        $status.removeClass('success error').text('');
+        if (message) {
+            $status.addClass(type || '').text(message);
+        }
+    }
+
+    $(function () {
+        var settings = window.bookcreatorClaudeSettings || {};
+        var $button = $('#bookcreator_claude_test_connection');
+        var $status = $('#bookcreator_claude_test_connection_status');
+
+        if (!$button.length || !settings.ajaxUrl) {
+            return;
+        }
+
+        $button.on('click', function () {
+            updateStatus($status, settings.messages ? settings.messages.testing : '');
+            $button.prop('disabled', true);
+
+            $.ajax({
+                url: settings.ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'bookcreator_test_claude_connection',
+                    nonce: settings.nonce
+                }
+            })
+                .done(function (response) {
+                    if (response && response.success && response.data && response.data.message) {
+                        updateStatus($status, response.data.message, 'success');
+                    } else if (response && response.data && response.data.message) {
+                        updateStatus($status, response.data.message, 'error');
+                    } else if (settings.messages && settings.messages.genericError) {
+                        updateStatus($status, settings.messages.genericError, 'error');
+                    }
+                })
+                .fail(function (jqXHR) {
+                    var message = settings.messages ? settings.messages.genericError : '';
+                    if (jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
+                        message = jqXHR.responseJSON.data.message;
+                    }
+                    updateStatus($status, message, 'error');
+                })
+                .always(function () {
+                    $button.prop('disabled', false);
+                });
+        });
+    });
+})(jQuery);


### PR DESCRIPTION
## Summary
- add a Claude connection test button to the settings screen and handle the AJAX request on the server
- provide a direct link to the Anthropic Console when prompting for the API key
- enqueue a dedicated admin script to drive the connection test UX

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d272be4c8c8332a1aca2072e7039d7