### PR TITLE
Add publisher logo styling controls to ePub template

### DIFF
--- a/templates/single-book_creator.php
+++ b/templates/single-book_creator.php
@@ -183,7 +183,7 @@ get_header();
                     <?php if ( $publisher_logo_id ) : ?>
                         <figure class="bookcreator-book__publisher-logo">
                             <figcaption><?php esc_html_e( 'Logo editore', 'bookcreator' ); ?></figcaption>
-                            <?php echo wp_get_attachment_image( $publisher_logo_id, 'medium' ); ?>
+                            <?php echo wp_get_attachment_image( $publisher_logo_id, 'medium', false, array( 'class' => 'bookcreator-frontispiece__publisher-logo-image' ) ); ?>
                         </figure>
                     <?php endif; ?>
                     <?php if ( $cover_id ) : ?>


### PR DESCRIPTION
## Summary
- add a stylable ePub template section for the publisher logo with support for width, alignment, margins and padding
- surface a width percentage control in the template editor UI and clamp stored values to 0-100%
- update generated ePub/PDF markup and front-end template to use a dedicated logo image class and apply the configured styles

## Testing
- php -l bookcreator.php
- php -l templates/single-book_creator.php

------
https://chatgpt.com/codex/tasks/task_e_68d3a1fa21cc8332ac02ceb4146b7c06