### PR TITLE
Handle missing hyphenation patterns gracefully

### DIFF
--- a/mpdf-8-1-0/src/Hyphenator.php
+++ b/mpdf-8-1-0/src/Hyphenator.php
@@ -165,7 +165,16 @@ class Hyphenator
 
 	private function loadPatterns()
 	{
-		$patterns = require __DIR__ . '/../data/patterns/' . $this->mpdf->SHYlang . '.php';
+                $patternFile = __DIR__ . '/../data/patterns/' . $this->mpdf->SHYlang . '.php';
+
+                if (!is_file($patternFile)) {
+                        $this->patterns = [];
+                        $this->loadedPatterns = $this->mpdf->SHYlang;
+
+                        return;
+                }
+
+                $patterns = require $patternFile;
 		$patterns = explode(' ', $patterns);
 
 		$new_patterns = [];


### PR DESCRIPTION
## Summary
- guard the hyphenation pattern loader against missing language files
- default to empty pattern sets so PDF generation can continue without fatal errors

## Testing
- php -l mpdf-8-1-0/src/Hyphenator.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c77f4f6883328c3c3e1585b7c861