### PR TITLE
Allow JSON imports when MIME check fails

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -4681,8 +4681,10 @@ function bookcreator_handle_template_actions() {
                     if ( ! function_exists( 'wp_check_filetype_and_ext' ) ) {
                         require_once ABSPATH . 'wp-admin/includes/file.php';
                     }
-                    $filetype = wp_check_filetype_and_ext( $file['tmp_name'], isset( $file['name'] ) ? $file['name'] : '', array( 'json' => 'application/json' ) );
-                    if ( empty( $filetype['ext'] ) || 'json' !== $filetype['ext'] ) {
+                    $filename      = isset( $file['name'] ) ? $file['name'] : '';
+                    $filetype      = wp_check_filetype_and_ext( $file['tmp_name'], $filename, array( 'json' => 'application/json' ) );
+                    $has_json_ext  = $filename && 'json' === strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
+                    if ( ( empty( $filetype['ext'] ) || 'json' !== $filetype['ext'] ) && ! $has_json_ext ) {
                         $status  = 'error';
                         $message = __( 'Il file caricato deve essere in formato JSON.', 'bookcreator' );
                     } else {


### PR DESCRIPTION
## Summary
- allow template imports to accept JSON files even when MIME detection fails
- fall back to validating the uploaded filename extension before rejecting the file

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d3ccc4dbac8332ad68b0119e679150