### PR TITLE
Fix PDF index rendering and add image alignment styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,3 +52,28 @@ h1[data-align-last-split-element], h2[data-align-last-split-element], h3[data-al
 #toc ol ol {
   margin-left: 1.5rem;
 }
+
+.alignleft {
+  float: left;
+  margin: 0 1.5rem 1.5rem 0;
+}
+
+.alignright {
+  float: right;
+  margin: 0 0 1.5rem 1.5rem;
+}
+
+.alignleft img,
+.alignright img {
+  display: block;
+}
+
+.aligncenter {
+  display: block;
+  margin: 0 auto 1.5rem;
+  text-align: center;
+}
+
+.aligncenter img {
+  display: inline-block;
+}


### PR DESCRIPTION
## Summary
- add a reusable helper that builds the PDF index using template texts and translations and insert it immediately after the preface when enabled
- respect the template visibility flag when rendering the PDF index so the toggle in the template works as expected
- add WordPress image alignment class styles (.alignleft/.aligncenter/.alignright) to the generated stylesheets and front-end CSS so aligned images render correctly in HTML, EPUB, and PDF outputs

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d3f04be3408332b38cba69cc45e28c