### PR TITLE
Enable BookCreator role to create chapters and paragraphs

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -151,7 +151,7 @@ function bookcreator_get_post_type_capabilities_map( $singular, $plural ) {
         'read_post'              => 'read_' . $singular,
         'delete_post'            => 'delete_' . $singular,
         'edit_posts'             => $edit_plural_cap,
-        'create_posts'           => $edit_plural_cap,
+        'create_posts'           => 'create_' . $plural,
         'edit_others_posts'      => 'edit_others_' . $plural,
         'publish_posts'          => 'publish_' . $plural,
         'read_private_posts'     => 'read_private_' . $plural,


### PR DESCRIPTION
## Summary
- require the dedicated `create_*` capabilities when WordPress checks whether a user can add new BookCreator content

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68d556711ec48332b0b356b468984eb1