### PR TITLE
Start BookCreator role from subscriber capabilities

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -165,7 +165,17 @@ function bookcreator_get_post_type_capabilities_map( $singular, $plural ) {
 }
 
 function bookcreator_get_bookcreator_role_capabilities() {
-    return array(
+    $base_capabilities = array(
+        'read'    => true,
+        'level_0' => true,
+    );
+
+    $subscriber_role = get_role( 'subscriber' );
+    if ( $subscriber_role instanceof WP_Role ) {
+        $base_capabilities = array_merge( $base_capabilities, $subscriber_role->capabilities );
+    }
+
+    $bookcreator_capabilities = array(
         'read'                                   => true,
         'upload_files'                           => true,
         'edit_bookcreator_book'                  => true,
@@ -209,6 +219,8 @@ function bookcreator_get_bookcreator_role_capabilities() {
         'bookcreator_manage_structures'          => true,
         'bookcreator_generate_exports'           => true,
     );
+
+    return array_merge( $base_capabilities, $bookcreator_capabilities );
 }
 
 function bookcreator_register_roles() {


### PR DESCRIPTION
## Summary
- initialize the BookCreator role capabilities by inheriting the base subscriber permissions
- merge the plugin-specific permissions on top to ensure level_0/read defaults stay available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d558dc1c9083329848bb6a608e95ad