### PR TITLE
Add missing role registration helper

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -219,16 +219,24 @@ function bookcreator_get_plugin_capabilities() {
     );
 }
 
-function bookcreator_assign_capabilities_to_administrators() {
-    $admin = get_role( 'administrator' );
+function bookcreator_assign_capabilities_to_role( $role_name, array $capabilities ) {
+    $role = get_role( $role_name );
 
-    if ( ! $admin ) {
+    if ( ! $role ) {
         return;
     }
 
-    foreach ( bookcreator_get_plugin_capabilities() as $capability ) {
-        $admin->add_cap( $capability );
+    foreach ( $capabilities as $capability ) {
+        $role->add_cap( $capability );
     }
+}
+
+function bookcreator_register_roles() {
+    bookcreator_assign_capabilities_to_role( 'administrator', bookcreator_get_plugin_capabilities() );
+}
+
+function bookcreator_assign_capabilities_to_administrators() {
+    bookcreator_assign_capabilities_to_role( 'administrator', bookcreator_get_plugin_capabilities() );
 }
 add_action( 'init', 'bookcreator_assign_capabilities_to_administrators', 0 );
 


### PR DESCRIPTION
## Summary
- add the missing `bookcreator_register_roles()` helper that assigns plugin capabilities to administrators
- share capability assignment logic through a reusable `bookcreator_assign_capabilities_to_role()` function

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d56427d8b08332ab83b31b5cc314df