### PR TITLE
Revamp ePub Designer layout and navigation

### DIFF
--- a/css/epub-designer.css
+++ b/css/epub-designer.css
@@ -20,7 +20,7 @@ body.book_creator_page_bookcreator-epub-designer #wpfooter {
     height: 100vh;
     display: flex;
     flex-direction: column;
-    background: linear-gradient(135deg, #f8fafc 0%, #e0f2fe 45%, #f1f5f9 100%);
+    background: #f8fafc;
     color: #0f172a;
     font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     z-index: 100000;
@@ -130,7 +130,7 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
 }
 
 .bookcreator-epub-designer__stage canvas {
-    border-radius: 32px 32px 0 0;
+    border-radius: 0;
 }
 
 .bookcreator-epub-designer__empty-message {
@@ -151,6 +151,63 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
 
 .bookcreator-epub-designer__empty-message.is-visible {
     display: flex;
+}
+
+.bookcreator-epub-designer__nav {
+    position: absolute;
+    left: 50%;
+    bottom: 32px;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    padding: 10px 18px;
+    font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    color: #0f172a;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
+    backdrop-filter: blur(4px);
+}
+
+.bookcreator-epub-designer__nav-button {
+    appearance: none;
+    background: none;
+    border: none;
+    color: #0f172a;
+    font-size: 18px;
+    padding: 6px 10px;
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+.bookcreator-epub-designer__nav-button:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+}
+
+.bookcreator-epub-designer__nav-button:hover:not(:disabled),
+.bookcreator-epub-designer__nav-button:focus-visible:not(:disabled) {
+    color: #1d4ed8;
+}
+
+.bookcreator-epub-designer__nav-status {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    min-width: 180px;
+}
+
+.bookcreator-epub-designer__nav-title {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.bookcreator-epub-designer__nav-indicator {
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 }
 
 .bookcreator-epub-designer__hud {


### PR DESCRIPTION
## Summary
- restructure the ePub Designer data pipeline to serve ordered page blocks and include chapter/paragraph content
- rebuild the Konva rendering to display a single sharp-cornered page with info tooltips, plain Times typography, and publisher imagery
- add simulated page navigation controls and updated styling/strings to guide exploring the entire book

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d7e4a66f4483328eae6f6ebfb5c3cc