### PR TITLE
Refine ePub designer continuous preview

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -7564,29 +7564,16 @@ function bookcreator_render_epub_designer_page() {
                     <?php esc_html_e( 'Nessun libro disponibile. Crea un nuovo libro per iniziare a progettare lo stile.', 'bookcreator' ); ?>
                 </div>
             </div>
-            <div class="bookcreator-epub-designer__nav" role="navigation" aria-label="<?php esc_attr_e( 'Navigazione pagine simulate', 'bookcreator' ); ?>">
-                <button type="button" class="bookcreator-epub-designer__nav-button" data-epub-designer-prev>
-                    <span class="screen-reader-text"><?php esc_html_e( 'Pagina precedente', 'bookcreator' ); ?></span>
-                    <span aria-hidden="true">&#8592;</span>
-                </button>
-                <div class="bookcreator-epub-designer__nav-status">
-                    <span id="bookcreator-epub-designer-page-title" class="bookcreator-epub-designer__nav-title"></span>
-                    <span id="bookcreator-epub-designer-page-indicator" class="bookcreator-epub-designer__nav-indicator"></span>
-                </div>
-                <button type="button" class="bookcreator-epub-designer__nav-button" data-epub-designer-next>
-                    <span class="screen-reader-text"><?php esc_html_e( 'Pagina successiva', 'bookcreator' ); ?></span>
-                    <span aria-hidden="true">&#8594;</span>
-                </button>
-            </div>
             <div class="bookcreator-epub-designer__hud">
                 <h2 class="bookcreator-epub-designer__hud-title"><?php esc_html_e( 'Anteprima stile ePub', 'bookcreator' ); ?></h2>
                 <p class="bookcreator-epub-designer__hud-text">
-                    <?php esc_html_e( 'Utilizza la navigazione per esplorare tutte le pagine simulate del libro selezionato.', 'bookcreator' ); ?>
+                    <?php esc_html_e( 'Scorri il contenuto per visualizzare in sequenza i campi del libro selezionato.', 'bookcreator' ); ?>
                 </p>
                 <ul class="bookcreator-epub-designer__hud-list">
                     <li><?php esc_html_e( 'Seleziona un libro dal menu in alto a sinistra.', 'bookcreator' ); ?></li>
-                    <li><?php esc_html_e( 'Osserva i campi disponibili e pianifica lo stile tipografico.', 'bookcreator' ); ?></li>
+                    <li><?php esc_html_e( 'Osserva tutti i campi disponibili visualizzati in ordine continuo.', 'bookcreator' ); ?></li>
                     <li><?php esc_html_e( 'Passa il cursore sulle icone informative per visualizzare il nome dei campi.', 'bookcreator' ); ?></li>
+                    <li><?php esc_html_e( 'Clicca su testi e immagini per selezionarli e mettere in risalto il contenuto.', 'bookcreator' ); ?></li>
                 </ul>
             </div>
         </div>
@@ -7626,15 +7613,11 @@ function bookcreator_epub_designer_admin_enqueue( $hook ) {
             'initialBookId' => $initial_id,
             'closeUrl'      => esc_url_raw( admin_url( 'edit.php?post_type=book_creator' ) ),
             'strings'       => array(
-                'noBooks'     => __( 'Nessun libro disponibile. Crea un nuovo libro per iniziare.', 'bookcreator' ),
-                'emptyValue'  => __( 'Contenuto non disponibile', 'bookcreator' ),
-                /* translators: %1$s: numero di pagine simulate disponibili. */
-                'bookInfo'    => __( '%1$s pagine simulate', 'bookcreator' ),
-                /* translators: 1: indice pagina corrente, 2: numero totale di pagine. */
-                'pageIndicator' => __( 'Pagina %1$s di %2$s', 'bookcreator' ),
-                /* translators: %1$s numero della pagina usato come fallback. */
-                'pageTitleFallback' => __( 'Pagina %1$s', 'bookcreator' ),
-                'noPages'     => __( 'Nessuna pagina disponibile per questo libro.', 'bookcreator' ),
+                'noBooks'             => __( 'Nessun libro disponibile. Crea un nuovo libro per iniziare.', 'bookcreator' ),
+                'emptyValue'          => '',
+                /* translators: %1$s: numero di campi visibili. */
+                'bookInfo'            => __( '%1$s campi visibili', 'bookcreator' ),
+                'noPages'             => '',
                 'indexBulletPrimary'   => '•',
                 'indexBulletSecondary' => '◦',
             ),

--- a/css/epub-designer.css
+++ b/css/epub-designer.css
@@ -127,6 +127,7 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
 .bookcreator-epub-designer__stage {
     flex: 1;
     position: relative;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.9), rgba(226, 232, 240, 0.9)), #e2e8f0;
 }
 
 .bookcreator-epub-designer__stage canvas {
@@ -151,63 +152,6 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
 
 .bookcreator-epub-designer__empty-message.is-visible {
     display: flex;
-}
-
-.bookcreator-epub-designer__nav {
-    position: absolute;
-    left: 50%;
-    bottom: 32px;
-    transform: translateX(-50%);
-    display: flex;
-    align-items: center;
-    gap: 24px;
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    padding: 10px 18px;
-    font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-    color: #0f172a;
-    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
-    backdrop-filter: blur(4px);
-}
-
-.bookcreator-epub-designer__nav-button {
-    appearance: none;
-    background: none;
-    border: none;
-    color: #0f172a;
-    font-size: 18px;
-    padding: 6px 10px;
-    cursor: pointer;
-    transition: color 0.2s ease;
-}
-
-.bookcreator-epub-designer__nav-button:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
-}
-
-.bookcreator-epub-designer__nav-button:hover:not(:disabled),
-.bookcreator-epub-designer__nav-button:focus-visible:not(:disabled) {
-    color: #1d4ed8;
-}
-
-.bookcreator-epub-designer__nav-status {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    min-width: 180px;
-}
-
-.bookcreator-epub-designer__nav-title {
-    font-size: 14px;
-    font-weight: 600;
-}
-
-.bookcreator-epub-designer__nav-indicator {
-    font-size: 12px;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
 }
 
 .bookcreator-epub-designer__hud {


### PR DESCRIPTION
## Summary
- show ePub Designer book fields in a single scrollable canvas with updated info badges and selection highlights
- remove slide navigation markup/styles and refresh localized strings to reflect the continuous preview
- tweak stage styling to match the new ePub-inspired layout and guidance copy in the HUD

## Testing
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68d7eafdeb98833296173dcd6f5bca05