### PR TITLE
Add interactive ePub designer preview with styling toolbar

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -7559,22 +7559,138 @@ function bookcreator_render_epub_designer_page() {
             </div>
         </div>
         <div class="bookcreator-epub-designer__body">
-            <div class="bookcreator-epub-designer__stage" id="bookcreator-epub-designer-stage">
-                <div class="bookcreator-epub-designer__empty-message" id="bookcreator-epub-designer-empty">
-                    <?php esc_html_e( 'Nessun libro disponibile. Crea un nuovo libro per iniziare a progettare lo stile.', 'bookcreator' ); ?>
+            <div class="bookcreator-epub-designer__workspace">
+                <div class="bookcreator-epub-designer__stage">
+                    <div class="bookcreator-epub-designer__canvas-wrapper">
+                        <div id="bookcreator-epub-designer-stage" class="bookcreator-epub-designer__canvas"></div>
+                    </div>
+                    <div class="bookcreator-epub-designer__empty-message" id="bookcreator-epub-designer-empty">
+                        <?php esc_html_e( 'Nessun libro disponibile. Crea un nuovo libro per iniziare a progettare lo stile.', 'bookcreator' ); ?>
+                    </div>
                 </div>
-            </div>
-            <div class="bookcreator-epub-designer__hud">
-                <h2 class="bookcreator-epub-designer__hud-title"><?php esc_html_e( 'Anteprima stile ePub', 'bookcreator' ); ?></h2>
-                <p class="bookcreator-epub-designer__hud-text">
-                    <?php esc_html_e( 'Scorri il contenuto per visualizzare in sequenza i campi del libro selezionato.', 'bookcreator' ); ?>
-                </p>
-                <ul class="bookcreator-epub-designer__hud-list">
-                    <li><?php esc_html_e( 'Seleziona un libro dal menu in alto a sinistra.', 'bookcreator' ); ?></li>
-                    <li><?php esc_html_e( 'Osserva tutti i campi disponibili visualizzati in ordine continuo.', 'bookcreator' ); ?></li>
-                    <li><?php esc_html_e( 'Passa il cursore sulle icone informative per visualizzare il nome dei campi.', 'bookcreator' ); ?></li>
-                    <li><?php esc_html_e( 'Clicca su testi e immagini per selezionarli e mettere in risalto il contenuto.', 'bookcreator' ); ?></li>
-                </ul>
+                <div class="bookcreator-epub-toolbar is-hidden" id="bookcreator-epub-toolbar" aria-hidden="true">
+                    <div class="bookcreator-epub-toolbar__header">
+                        <div class="bookcreator-epub-toolbar__title">
+                            <span class="bookcreator-epub-toolbar__title-label"><?php esc_html_e( 'Campo selezionato', 'bookcreator' ); ?></span>
+                            <strong id="bookcreator-epub-toolbar-field" class="bookcreator-epub-toolbar__title-value">—</strong>
+                        </div>
+                        <button type="button" class="bookcreator-epub-toolbar__close" data-epub-toolbar-close aria-label="<?php esc_attr_e( 'Chiudi barra strumenti', 'bookcreator' ); ?>">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="bookcreator-epub-toolbar__content">
+                        <div class="bookcreator-epub-toolbar__group bookcreator-epub-toolbar__group--grow">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Dimensione font', 'bookcreator' ); ?></span>
+                            <div class="bookcreator-epub-toolbar__stepper" data-text-control>
+                                <button type="button" class="bookcreator-epub-toolbar__step" data-step-control="font-size" data-step="-0.1" aria-label="<?php esc_attr_e( 'Diminuisci dimensione font', 'bookcreator' ); ?>">−</button>
+                                <input type="number" step="0.1" min="0.6" max="6" value="1.2" data-epub-control="font-size" class="bookcreator-epub-toolbar__input" />
+                                <button type="button" class="bookcreator-epub-toolbar__step" data-step-control="font-size" data-step="0.1" aria-label="<?php esc_attr_e( 'Aumenta dimensione font', 'bookcreator' ); ?>">+</button>
+                                <span class="bookcreator-epub-toolbar__suffix">rem</span>
+                            </div>
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Altezza riga', 'bookcreator' ); ?></span>
+                            <div class="bookcreator-epub-toolbar__stepper" data-text-control>
+                                <button type="button" class="bookcreator-epub-toolbar__step" data-step-control="line-height" data-step="-0.05" aria-label="<?php esc_attr_e( 'Diminuisci altezza riga', 'bookcreator' ); ?>">−</button>
+                                <input type="number" step="0.05" min="1" max="3" value="1.4" data-epub-control="line-height" class="bookcreator-epub-toolbar__input" />
+                                <button type="button" class="bookcreator-epub-toolbar__step" data-step-control="line-height" data-step="0.05" aria-label="<?php esc_attr_e( 'Aumenta altezza riga', 'bookcreator' ); ?>">+</button>
+                            </div>
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group bookcreator-epub-toolbar__group--grow">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Famiglia font', 'bookcreator' ); ?></span>
+                            <select data-epub-control="font-family" class="bookcreator-epub-toolbar__select" data-text-control>
+                                <option value="'Georgia', serif">Georgia</option>
+                                <option value="'Times New Roman', serif">Times New Roman</option>
+                                <option value="'Garamond', serif">Garamond</option>
+                                <option value="'Palatino Linotype', serif">Palatino</option>
+                                <option value="'Arial', sans-serif">Arial</option>
+                                <option value="'Helvetica Neue', sans-serif">Helvetica Neue</option>
+                                <option value="'Segoe UI', sans-serif">Segoe UI</option>
+                                <option value="'Courier New', monospace">Courier New</option>
+                            </select>
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Stile font', 'bookcreator' ); ?></span>
+                            <select data-epub-control="font-style" class="bookcreator-epub-toolbar__select" data-text-control>
+                                <option value="normal"><?php esc_html_e( 'Normale', 'bookcreator' ); ?></option>
+                                <option value="italic"><?php esc_html_e( 'Corsivo', 'bookcreator' ); ?></option>
+                            </select>
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Peso font', 'bookcreator' ); ?></span>
+                            <select data-epub-control="font-weight" class="bookcreator-epub-toolbar__select" data-text-control>
+                                <option value="300">300</option>
+                                <option value="400">400</option>
+                                <option value="500">500</option>
+                                <option value="600">600</option>
+                                <option value="700">700</option>
+                            </select>
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Sillabazione', 'bookcreator' ); ?></span>
+                            <button type="button" class="bookcreator-epub-toolbar__toggle" data-epub-control="hyphenate" data-text-control><?php esc_html_e( 'Attiva', 'bookcreator' ); ?></button>
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group bookcreator-epub-toolbar__group--align">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Allineamento', 'bookcreator' ); ?></span>
+                            <div class="bookcreator-epub-toolbar__alignment" role="group">
+                                <button type="button" class="bookcreator-epub-toolbar__align" data-epub-align="left" aria-label="<?php esc_attr_e( 'Allinea a sinistra', 'bookcreator' ); ?>" data-text-control></button>
+                                <button type="button" class="bookcreator-epub-toolbar__align" data-epub-align="center" aria-label="<?php esc_attr_e( 'Allinea al centro', 'bookcreator' ); ?>" data-text-control></button>
+                                <button type="button" class="bookcreator-epub-toolbar__align" data-epub-align="right" aria-label="<?php esc_attr_e( 'Allinea a destra', 'bookcreator' ); ?>" data-text-control></button>
+                                <button type="button" class="bookcreator-epub-toolbar__align" data-epub-align="justify" aria-label="<?php esc_attr_e( 'Giustifica testo', 'bookcreator' ); ?>" data-text-control></button>
+                            </div>
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Colore testo', 'bookcreator' ); ?></span>
+                            <input type="color" data-epub-control="color" class="bookcreator-epub-toolbar__color" value="#1f2937" data-text-control />
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Colore sfondo', 'bookcreator' ); ?></span>
+                            <input type="color" data-epub-control="background-color" class="bookcreator-epub-toolbar__color" value="#ffffff" />
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group bookcreator-epub-toolbar__group--box">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Margini (em)', 'bookcreator' ); ?></span>
+                            <div class="bookcreator-epub-toolbar__box-grid">
+                                <label class="bookcreator-epub-toolbar__box-field">
+                                    <span><?php esc_html_e( 'Su', 'bookcreator' ); ?></span>
+                                    <input type="number" step="0.1" min="0" value="0.6" data-epub-control="margin-top" class="bookcreator-epub-toolbar__input" />
+                                </label>
+                                <label class="bookcreator-epub-toolbar__box-field">
+                                    <span><?php esc_html_e( 'Dx', 'bookcreator' ); ?></span>
+                                    <input type="number" step="0.1" min="0" value="1" data-epub-control="margin-right" class="bookcreator-epub-toolbar__input" />
+                                </label>
+                                <label class="bookcreator-epub-toolbar__box-field">
+                                    <span><?php esc_html_e( 'Giù', 'bookcreator' ); ?></span>
+                                    <input type="number" step="0.1" min="0" value="0.6" data-epub-control="margin-bottom" class="bookcreator-epub-toolbar__input" />
+                                </label>
+                                <label class="bookcreator-epub-toolbar__box-field">
+                                    <span><?php esc_html_e( 'Sx', 'bookcreator' ); ?></span>
+                                    <input type="number" step="0.1" min="0" value="1" data-epub-control="margin-left" class="bookcreator-epub-toolbar__input" />
+                                </label>
+                            </div>
+                        </div>
+                        <div class="bookcreator-epub-toolbar__group bookcreator-epub-toolbar__group--box">
+                            <span class="bookcreator-epub-toolbar__label"><?php esc_html_e( 'Padding (em)', 'bookcreator' ); ?></span>
+                            <div class="bookcreator-epub-toolbar__box-grid">
+                                <label class="bookcreator-epub-toolbar__box-field">
+                                    <span><?php esc_html_e( 'Su', 'bookcreator' ); ?></span>
+                                    <input type="number" step="0.1" min="0" value="0.8" data-epub-control="padding-top" class="bookcreator-epub-toolbar__input" />
+                                </label>
+                                <label class="bookcreator-epub-toolbar__box-field">
+                                    <span><?php esc_html_e( 'Dx', 'bookcreator' ); ?></span>
+                                    <input type="number" step="0.1" min="0" value="1" data-epub-control="padding-right" class="bookcreator-epub-toolbar__input" />
+                                </label>
+                                <label class="bookcreator-epub-toolbar__box-field">
+                                    <span><?php esc_html_e( 'Giù', 'bookcreator' ); ?></span>
+                                    <input type="number" step="0.1" min="0" value="0.8" data-epub-control="padding-bottom" class="bookcreator-epub-toolbar__input" />
+                                </label>
+                                <label class="bookcreator-epub-toolbar__box-field">
+                                    <span><?php esc_html_e( 'Sx', 'bookcreator' ); ?></span>
+                                    <input type="number" step="0.1" min="0" value="1" data-epub-control="padding-left" class="bookcreator-epub-toolbar__input" />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/css/epub-designer.css
+++ b/css/epub-designer.css
@@ -20,7 +20,7 @@ body.book_creator_page_bookcreator-epub-designer #wpfooter {
     height: 100vh;
     display: flex;
     flex-direction: column;
-    background: #f8fafc;
+    background: linear-gradient(180deg, #eff6ff 0%, #f8fafc 32%, #f1f5f9 100%);
     color: #0f172a;
     font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     z-index: 100000;
@@ -42,31 +42,33 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 32px;
-    min-height: 72px;
-    background: linear-gradient(90deg, rgba(15, 23, 42, 0.92) 0%, rgba(30, 64, 175, 0.92) 50%, rgba(2, 132, 199, 0.92) 100%);
-    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
-    color: #fff;
+    gap: 24px;
+    padding: 16px 32px;
+    min-height: 76px;
+    background: linear-gradient(135deg, #1d4ed8 0%, #2563eb 38%, #06b6d4 100%);
+    color: #ffffff;
+    box-shadow: 0 18px 42px rgba(15, 23, 42, 0.28);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 .bookcreator-epub-designer__toolbar-left,
 .bookcreator-epub-designer__toolbar-right {
     display: flex;
     align-items: center;
-    gap: 16px;
+    gap: 18px;
 }
 
 .bookcreator-epub-designer__logo {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.12);
-    padding: 10px 18px;
+    padding: 10px 20px;
     border-radius: 999px;
+    background: rgba(255, 255, 255, 0.16);
     font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    letter-spacing: 0.1em;
     font-size: 12px;
+    text-transform: uppercase;
 }
 
 .bookcreator-epub-designer__label {
@@ -78,27 +80,28 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
 .bookcreator-epub-designer__select {
     appearance: none;
     border: none;
-    border-radius: 12px;
-    padding: 12px 42px 12px 16px;
+    border-radius: 14px;
+    padding: 12px 44px 12px 18px;
     font-size: 14px;
     font-weight: 500;
     color: #0f172a;
-    background: #fff url('data:image/svg+xml,%3Csvg width="14" height="8" viewBox="0 0 14 8" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M1 1.5L7 6.5L13 1.5" stroke="%230f172a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E') no-repeat right 16px center;
-    box-shadow: 0 15px 30px rgba(15, 23, 42, 0.18);
+    background: #ffffff url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="14" height="8" fill="none" viewBox="0 0 14 8"%3E%3Cpath stroke="%230f172a" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.4" d="m1 1.5 6 5 6-5"/%3E%3C/svg%3E') no-repeat right 16px center;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
     cursor: pointer;
 }
 
 .bookcreator-epub-designer__select:disabled {
-    opacity: 0.5;
+    opacity: 0.45;
     cursor: not-allowed;
 }
 
 .bookcreator-epub-designer__status {
     display: flex;
     flex-direction: column;
+    align-items: flex-end;
     gap: 4px;
-    min-width: 200px;
     text-align: right;
+    min-width: 200px;
 }
 
 .bookcreator-epub-designer__status-title {
@@ -108,7 +111,7 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
 
 .bookcreator-epub-designer__status-meta {
     font-size: 13px;
-    opacity: 0.75;
+    opacity: 0.8;
 }
 
 .bookcreator-epub-designer__close {
@@ -120,18 +123,53 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
 .bookcreator-epub-designer__body {
     flex: 1;
     display: flex;
+    justify-content: center;
+    padding: 32px 40px 40px;
     position: relative;
     overflow: hidden;
 }
 
-.bookcreator-epub-designer__stage {
+.bookcreator-epub-designer__workspace {
     flex: 1;
     position: relative;
-    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.9), rgba(226, 232, 240, 0.9)), #e2e8f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
-.bookcreator-epub-designer__stage canvas {
-    border-radius: 0;
+.bookcreator-epub-designer__stage {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.bookcreator-epub-designer__canvas-wrapper {
+    position: relative;
+    width: min(1100px, 100%);
+    aspect-ratio: 1100 / 700;
+    border-radius: 36px;
+    background: radial-gradient(circle at 20% 18%, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.78)), #dbeafe;
+    box-shadow: 0 40px 90px rgba(15, 23, 42, 0.25);
+    padding: 32px;
+    display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+}
+
+.bookcreator-epub-designer__canvas {
+    position: relative;
+    flex: 1;
+    border-radius: 28px;
+    overflow: hidden;
+    background: #ffffff;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.bookcreator-epub-designer__canvas canvas {
+    width: 100% !important;
+    height: 100% !important;
+    border-radius: 28px;
 }
 
 .bookcreator-epub-designer__empty-message {
@@ -144,55 +182,338 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
     font-size: 18px;
     font-weight: 500;
     color: rgba(15, 23, 42, 0.75);
-    background: rgba(255, 255, 255, 0.65);
-    backdrop-filter: blur(6px);
-    z-index: 10;
+    background: rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(8px);
+    z-index: 12;
     text-align: center;
+    border-radius: 28px;
 }
 
 .bookcreator-epub-designer__empty-message.is-visible {
     display: flex;
 }
 
-.bookcreator-epub-designer__hud {
+.bookcreator-epub-toolbar {
     position: absolute;
-    right: 48px;
-    top: 104px;
-    width: 280px;
-    padding: 24px 24px 28px;
-    border-radius: 24px;
-    background: rgba(15, 23, 42, 0.85);
-    color: #e2e8f0;
-    box-shadow: 0 25px 45px rgba(15, 23, 42, 0.35);
-    backdrop-filter: blur(12px);
-    pointer-events: none;
+    top: 24px;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: min(980px, calc(100% - 96px));
+    background: rgba(255, 255, 255, 0.96);
+    color: #0f172a;
+    border-radius: 26px;
+    box-shadow: 0 28px 64px rgba(15, 23, 42, 0.25);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    padding: 20px 26px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    z-index: 30;
+    backdrop-filter: blur(18px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
-.bookcreator-epub-designer__hud-title {
+.bookcreator-epub-toolbar.is-hidden {
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -12px);
+}
+
+.bookcreator-epub-toolbar__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.bookcreator-epub-toolbar__title {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.bookcreator-epub-toolbar__title-label {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(15, 23, 42, 0.55);
+    font-weight: 600;
+}
+
+.bookcreator-epub-toolbar__title-value {
+    font-size: 20px;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.bookcreator-epub-toolbar__close {
+    width: 40px;
+    height: 40px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(226, 232, 240, 0.6);
+    color: #0f172a;
+    font-size: 24px;
+    line-height: 1;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.bookcreator-epub-toolbar__close:hover,
+.bookcreator-epub-toolbar__close:focus {
+    background: rgba(148, 163, 184, 0.25);
+    border-color: rgba(37, 99, 235, 0.45);
+}
+
+.bookcreator-epub-toolbar__content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px 20px;
+    align-items: end;
+}
+
+.bookcreator-epub-toolbar__group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    position: relative;
+}
+
+.bookcreator-epub-toolbar__group--grow {
+    min-width: 220px;
+}
+
+.bookcreator-epub-toolbar__group--align {
+    min-width: 220px;
+}
+
+.bookcreator-epub-toolbar__group--box {
+    min-width: 220px;
+}
+
+.bookcreator-epub-toolbar__label {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.bookcreator-epub-toolbar__input,
+.bookcreator-epub-toolbar__select {
+    width: 100%;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: rgba(248, 250, 252, 0.9);
+    color: #0f172a;
+    padding: 10px 14px;
+    font-size: 14px;
+    font-weight: 500;
+    box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.4);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bookcreator-epub-toolbar__input:focus,
+.bookcreator-epub-toolbar__select:focus {
+    border-color: rgba(37, 99, 235, 0.65);
+    box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.35);
+    outline: none;
+}
+
+.bookcreator-epub-toolbar__select {
+    appearance: none;
+    padding-right: 44px;
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="14" height="8" fill="none" viewBox="0 0 14 8"%3E%3Cpath stroke="%230f172a" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.4" d="m1 1.5 6 5 6-5"/%3E%3C/svg%3E');
+    background-repeat: no-repeat;
+    background-position: right 14px center;
+}
+
+.bookcreator-epub-toolbar__stepper {
+    display: grid;
+    grid-template-columns: 40px 1fr 40px auto;
+    gap: 6px;
+    align-items: center;
+    background: rgba(248, 250, 252, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    border-radius: 16px;
+    padding: 4px 10px;
+}
+
+.bookcreator-epub-toolbar__stepper .bookcreator-epub-toolbar__input {
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    padding: 0 6px;
+    text-align: center;
+    font-size: 14px;
+}
+
+.bookcreator-epub-toolbar__step {
+    width: 32px;
+    height: 32px;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(241, 245, 249, 0.9));
+    color: #0f172a;
     font-size: 18px;
     font-weight: 600;
-    margin: 0 0 12px;
-    color: #f8fafc;
-}
-
-.bookcreator-epub-designer__hud-text {
-    font-size: 14px;
-    margin: 0 0 16px;
-    line-height: 1.6;
-}
-
-.bookcreator-epub-designer__hud-list {
-    margin: 0;
-    padding-left: 20px;
-    font-size: 13px;
-    line-height: 1.6;
     display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bookcreator-epub-toolbar__step:hover,
+.bookcreator-epub-toolbar__step:focus {
+    border-color: rgba(37, 99, 235, 0.55);
+    box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+    outline: none;
+}
+
+.bookcreator-epub-toolbar__suffix {
+    font-size: 12px;
+    font-weight: 600;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.bookcreator-epub-toolbar__toggle {
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: rgba(248, 250, 252, 0.9);
+    color: #0f172a;
+    font-weight: 600;
+    padding: 10px 16px;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.bookcreator-epub-toolbar__toggle.is-active {
+    background: linear-gradient(135deg, #2563eb, #38bdf8);
+    border-color: rgba(37, 99, 235, 0.8);
+    color: #ffffff;
+    box-shadow: 0 10px 22px rgba(37, 99, 235, 0.28);
+}
+
+.bookcreator-epub-toolbar__alignment {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.bookcreator-epub-toolbar__align {
+    position: relative;
+    height: 42px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: rgba(248, 250, 252, 0.85);
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.bookcreator-epub-toolbar__align::before {
+    content: '';
+    position: absolute;
+    inset: 10px 12px;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    opacity: 0.8;
+}
+
+.bookcreator-epub-toolbar__align[data-epub-align="left"]::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='20' fill='none' viewBox='0 0 36 20'%3E%3Cpath stroke='%230f172a' stroke-linecap='round' stroke-width='2' d='M4 4h20M4 10h28M4 16h18'/%3E%3C/svg%3E");
+}
+
+.bookcreator-epub-toolbar__align[data-epub-align="center"]::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='20' fill='none' viewBox='0 0 36 20'%3E%3Cpath stroke='%230f172a' stroke-linecap='round' stroke-width='2' d='M8 4h20M4 10h28M8 16h20'/%3E%3C/svg%3E");
+}
+
+.bookcreator-epub-toolbar__align[data-epub-align="right"]::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='20' fill='none' viewBox='0 0 36 20'%3E%3Cpath stroke='%230f172a' stroke-linecap='round' stroke-width='2' d='M12 4h20M4 10h28M14 16h18'/%3E%3C/svg%3E");
+}
+
+.bookcreator-epub-toolbar__align[data-epub-align="justify"]::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='20' fill='none' viewBox='0 0 36 20'%3E%3Cpath stroke='%230f172a' stroke-linecap='round' stroke-width='2' d='M4 4h28M4 10h28M4 16h28'/%3E%3C/svg%3E");
+}
+
+.bookcreator-epub-toolbar__align:hover,
+.bookcreator-epub-toolbar__align:focus {
+    border-color: rgba(37, 99, 235, 0.55);
+    box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+    outline: none;
+}
+
+.bookcreator-epub-toolbar__align.is-active {
+    background: linear-gradient(135deg, #2563eb, #38bdf8);
+    border-color: rgba(37, 99, 235, 0.85);
+    box-shadow: 0 12px 28px rgba(37, 99, 235, 0.28);
+}
+
+.bookcreator-epub-toolbar__align.is-active::before {
+    filter: brightness(0) invert(1);
+    opacity: 1;
+}
+
+.bookcreator-epub-toolbar__color {
+    width: 100%;
+    height: 42px;
+    padding: 4px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: rgba(248, 250, 252, 0.9);
+    cursor: pointer;
+}
+
+.bookcreator-epub-toolbar__box-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.bookcreator-epub-toolbar__box-field {
+    display: flex;
+    flex-direction: column;
     gap: 6px;
 }
 
-@media screen and (max-width: 1200px) {
-    .bookcreator-epub-designer__hud {
-        display: none;
+.bookcreator-epub-toolbar__box-field span {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(15, 23, 42, 0.55);
+}
+
+.bookcreator-epub-toolbar__group.is-disabled {
+    opacity: 0.38;
+    pointer-events: none;
+}
+
+@media screen and (max-width: 1400px) {
+    .bookcreator-epub-toolbar {
+        width: min(960px, calc(100% - 60px));
+        padding: 18px 22px 22px;
+    }
+
+    .bookcreator-epub-toolbar__content {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+}
+
+@media screen and (max-width: 1100px) {
+    .bookcreator-epub-designer__body {
+        padding: 24px;
+    }
+
+    .bookcreator-epub-designer__canvas-wrapper {
+        padding: 24px;
+        border-radius: 28px;
+    }
+
+    .bookcreator-epub-toolbar {
+        width: min(900px, calc(100% - 48px));
     }
 }
 
@@ -204,6 +525,29 @@ body.admin-bar.book_creator_page_bookcreator-epub-designer #bookcreator-epub-des
     }
 
     .bookcreator-epub-designer__status {
+        align-items: flex-start;
         text-align: left;
+    }
+
+    .bookcreator-epub-toolbar {
+        position: static;
+        transform: none;
+        width: 100%;
+    }
+
+    .bookcreator-epub-toolbar.is-hidden {
+        opacity: 1;
+        pointer-events: auto;
+        transform: none;
+    }
+}
+
+@media screen and (max-width: 720px) {
+    #bookcreator-epub-designer-app {
+        font-size: 15px;
+    }
+
+    .bookcreator-epub-toolbar__content {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     }
 }

--- a/js/epub-designer.js
+++ b/js/epub-designer.js
@@ -3,780 +3,886 @@
         return;
     }
 
-    const data = window.bookcreatorEpubDesigner || {};
-    const container = document.getElementById('bookcreator-epub-designer-stage');
+    const BASE_WIDTH = 1100;
+    const BASE_HEIGHT = 700;
+    const PAGE_PADDING_X = 64;
+    const PAGE_PADDING_TOP = 48;
 
+    const data = window.bookcreatorEpubDesigner || {};
+    const strings = Object.assign({ bookInfo: '%1$s campi simulati' }, data.strings || {});
+
+    const container = document.getElementById('bookcreator-epub-designer-stage');
     if (!container) {
         return;
     }
 
-    const booksArray = Array.isArray(data.books) ? data.books : [];
-    const booksById = {};
+    const toolbar = document.getElementById('bookcreator-epub-toolbar');
+    const toolbarFieldLabel = document.getElementById('bookcreator-epub-toolbar-field');
+    const closeToolbarButton = toolbar ? toolbar.querySelector('[data-epub-toolbar-close]') : null;
+    const selector = document.getElementById('bookcreator-epub-designer-book');
+    const titleLabel = document.getElementById('bookcreator-epub-designer-selected-title');
+    const metaLabel = document.getElementById('bookcreator-epub-designer-book-meta');
+    const emptyMessage = document.getElementById('bookcreator-epub-designer-empty');
 
-    booksArray.forEach((book) => {
-        if (book && typeof book.id !== 'undefined') {
-            booksById[String(book.id)] = book;
+    if (selector) {
+        selector.disabled = true;
+    }
+
+    if (emptyMessage) {
+        emptyMessage.classList.remove('is-visible');
+    }
+
+    if (titleLabel) {
+        titleLabel.textContent = 'Anteprima ePub designer';
+    }
+
+    const sampleImageSrc =
+        "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='360' viewBox='0 0 640 360'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%2306b6d4'/%3E%3Cstop offset='50%25' stop-color='%233b82f6'/%3E%3Cstop offset='100%25' stop-color='%238b5cf6'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='0%25' y1='100%25' x2='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23f8fafc' stop-opacity='.9'/%3E%3Cstop offset='100%25' stop-color='%230f172a' stop-opacity='.2'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect fill='url(%23a)' x='0' y='0' width='640' height='360' rx='36'/%3E%3Cpath fill='url(%23b)' d='M0 280c120-24 180-60 320-60s200 36 320 60v80H0z'/%3E%3Cpath fill='rgba(255,255,255,0.85)' d='M180 124h280c18 0 24 14 12 30l-48 64c-8 12-24 12-32 0l-22-30c-6-8-18-8-24 0l-52 72c-8 12-22 12-30 0l-96-134c-12-16-4-32 12-32z'/%3E%3C/svg%3E";
+
+    const sampleFields = [
+        { id: 'bc_author', label: 'Autore principale', type: 'text', text: 'Maria Rossi', defaults: { fontSize: 1.25, align: 'center', fontWeight: '600', margin: { top: 0.8, bottom: 0.3, left: 0.8, right: 0.8 } } },
+        { id: 'bc_coauthors', label: 'Co-autori', type: 'text', text: 'Con la collaborazione di Luca Bianchi e Elisa Verdi', defaults: { fontSize: 1, fontStyle: 'italic', align: 'center', color: '#334155', margin: { top: 0, bottom: 0.8, left: 0.8, right: 0.8 } } },
+        { id: 'post_title', label: 'Titolo del libro', type: 'text', text: 'Guida completa a Corfù', defaults: { fontSize: 2.6, align: 'center', fontWeight: '700', lineHeight: 1.1, color: '#0f172a', margin: { top: 0.8, bottom: 0.4, left: 0.4, right: 0.4 }, padding: { top: 0.6, bottom: 0.6, left: 1, right: 1 } } },
+        { id: 'bc_subtitle', label: 'Sottotitolo', type: 'text', text: "Tra mito e mare: viaggio nell'isola dove Oriente e Occidente si incontrano", defaults: { fontSize: 1.35, align: 'center', fontWeight: '500', color: '#1d4ed8', margin: { top: 0, bottom: 1, left: 0.6, right: 0.6 }, backgroundColor: '#eef2ff', padding: { top: 0.8, bottom: 0.8, left: 1.4, right: 1.4 } } },
+        { id: 'bc_publisher_logo', label: 'Immagine editore', type: 'image', imageMaxHeight: 220, defaults: { margin: { top: 0.8, bottom: 0.8, left: 1.6, right: 1.6 }, padding: { top: 0.8, bottom: 0.8, left: 0.8, right: 0.8 }, backgroundColor: '#ffffff' } },
+        { id: 'bc_publisher', label: 'Editore', type: 'text', text: 'Sothìa · Infiniti modi di viaggiare', defaults: { fontSize: 1.05, align: 'center', color: '#0f172a', fontWeight: '600', letterSpacing: 0.08, margin: { top: 0.2, bottom: 1.2, left: 0.8, right: 0.8 } } },
+        { id: 'bc_dedication', label: 'Dedica', type: 'text', text: 'A chi crede che ogni viaggio inizi da un sogno condiviso.', defaults: { fontSize: 1.05, align: 'center', fontStyle: 'italic', color: '#1f2937', backgroundColor: '#f8fafc' } },
+        { id: 'bc_preface', label: 'Prefazione', type: 'text', text: 'Questa guida nasce sul mare Ionio, dove i sentieri di Corfù intrecciano storie di mercanti, filosofi e navigatori. Prima di immergerti nelle sue baie smeraldo, prenditi un momento per ascoltare il respiro dell’isola.', defaults: { fontSize: 1.05, lineHeight: 1.6, color: '#334155', margin: { top: 1.2, bottom: 1, left: 1, right: 1 } } },
+        { id: 'bc_acknowledgments', label: 'Ringraziamenti', type: 'text', text: 'Un grazie speciale a chi ha condiviso sentieri, taverne e tramonti con me: le persone del posto che hanno svelato la loro isola, e i lettori che ci hanno scritto per continuare a esplorare.', defaults: { fontSize: 1.02, lineHeight: 1.6, color: '#1f2937', backgroundColor: '#fef9c3', padding: { top: 0.9, bottom: 0.9, left: 1.2, right: 1.2 } } },
+        { id: 'bc_description', label: 'Descrizione del libro', type: 'text', text: 'Scopri una Corfù autentica attraverso itinerari tematici, mappe dettagliate e consigli pratici. Ogni capitolo combina curiosità storiche, percorsi naturalistici e degustazioni locali pensate per viaggiatori curiosi.', defaults: { fontSize: 1.05, lineHeight: 1.6, color: '#0f172a', margin: { top: 1, bottom: 1, left: 1, right: 1 } } },
+        { id: 'bc_copyright', label: 'Sezione Copyright', type: 'text', text: '© 2024 Sothìa Edizioni. Tutti i diritti riservati. Nessuna parte di questa pubblicazione può essere riprodotta senza il consenso scritto dell’editore.', defaults: { fontSize: 0.95, lineHeight: 1.5, color: '#475569', backgroundColor: '#f8fafc', margin: { top: 0.6, bottom: 0.6, left: 1.2, right: 1.2 } } },
+        { id: 'bc_isbn', label: 'Codice ISBN', type: 'text', text: 'ISBN 978-88-12345-678-9', defaults: { fontSize: 0.95, color: '#0f172a', fontWeight: '600', align: 'left', margin: { top: 0, bottom: 1, left: 1.2, right: 1.2 } } },
+        { id: 'bc_index', label: 'Indice (struttura generata)', type: 'text', text: 'Prefazione............................................. 9\nCapitolo 1 · Il viaggio ha inizio...................... 17\n   1.1 Preparativi essenziali....................... 20\n   1.2 Arrivi e primi sguardi....................... 28\nCapitolo 2 · Tra mito e mare.......................... 45\nAppendice............................................ 172', defaults: { fontFamily: "'Courier New', monospace", fontSize: 0.95, lineHeight: 1.4, color: '#0f172a', backgroundColor: '#ffffff', margin: { top: 1.2, bottom: 1.2, left: 1.2, right: 1.2 }, padding: { top: 1.2, bottom: 1.2, left: 1.6, right: 1.6 } } },
+        { id: 'chapter_title', label: 'Titolo del capitolo', type: 'text', text: 'Capitolo 1 · Il viaggio ha inizio', level: 1, defaults: { fontSize: 1.8, align: 'left', fontWeight: '700', color: '#1d4ed8', margin: { top: 1.4, bottom: 0.4, left: 0.6, right: 0.6 } } },
+        { id: 'chapter_content', label: 'Contenuto del capitolo', type: 'text', level: 1, text: 'L’alba su Corfù illumina le pietre della città vecchia mentre il profumo degli agrumi accompagna i primi passi. Questo capitolo propone un itinerario di tre giorni tra i bastioni veneziani, i mercati delle spezie e le calette nascoste verso Paleokastritsa.', defaults: { fontSize: 1.05, lineHeight: 1.7, margin: { top: 0.4, bottom: 0.8, left: 1, right: 1 }, color: '#0f172a' } },
+        { id: 'paragraph_title', label: 'Titolo del paragrafo', type: 'text', level: 2, text: '1.1 Preparativi essenziali', defaults: { fontSize: 1.3, fontWeight: '600', color: '#0f172a', margin: { top: 1.2, bottom: 0.4, left: 0.8, right: 0.8 } } },
+        { id: 'paragraph_content', label: 'Contenuto del paragrafo', type: 'text', level: 2, text: 'Prima di partire, raccogli una selezione di letture di viaggio, scarica le mappe offline e prepara una playlist che alterni cantautori italiani e canti tradizionali greci. In valigia trova spazio un taccuino resistente alla salsedine per annotare sapori e incontri.', defaults: { fontSize: 1.02, lineHeight: 1.7, margin: { top: 0.2, bottom: 0.6, left: 1.2, right: 1.2 }, color: '#1f2937' } },
+        { id: 'bc_footnotes', label: 'Note del paragrafo', type: 'text', level: 2, text: 'Nota 1 — Le linee di autobus interurbane partono ogni 45 minuti dalla stazione di San Rocco.', defaults: { fontSize: 0.9, lineHeight: 1.5, fontStyle: 'italic', color: '#475569', backgroundColor: '#f8fafc', margin: { top: 0.2, bottom: 0.4, left: 1.6, right: 1.6 } } },
+        { id: 'bc_citations', label: 'Citazioni del paragrafo', type: 'text', level: 2, text: '«Il viaggio è una porta attraverso la quale si esce dalla realtà per entrare in un universo inesplorato.» — Guy de Maupassant', defaults: { fontSize: 0.98, lineHeight: 1.6, fontStyle: 'italic', align: 'right', color: '#0f172a', margin: { top: 0.4, bottom: 0.8, left: 1.2, right: 1.2 }, backgroundColor: '#e0f2fe' } },
+        { id: 'bc_appendix', label: 'Appendice', type: 'text', text: 'Glossario di termini dialettali, consigli per il noleggio scooter e ricette essenziali per riprodurre a casa la cucina ionica.', defaults: { fontSize: 1, lineHeight: 1.6, backgroundColor: '#f1f5f9', margin: { top: 1.4, bottom: 0.6, left: 1.2, right: 1.2 }, padding: { top: 1, bottom: 1, left: 1.4, right: 1.4 } } },
+        { id: 'bc_bibliography', label: 'Bibliografia', type: 'text', text: '• K. Papadopoulos, "Isole Ionie Segrete", Atene 2018\n• L. Conti, "Rotte mediterranee", Roma 2021\n• Rivista Thalassa, dossier speciale Corfù, luglio 2023', defaults: { fontSize: 0.98, lineHeight: 1.5, fontFamily: "'Times New Roman', serif", color: '#111827', margin: { top: 0.8, bottom: 0.8, left: 1.2, right: 1.2 }, padding: { top: 0.8, bottom: 0.8, left: 1.2, right: 1.2 } } },
+        { id: 'bc_author_note', label: "Nota dell'autore", type: 'text', text: 'Viaggiare è un atto di fiducia: porta con te questo libro come bussola, ma lascia spazio all’imprevisto per trasformare il percorso in narrazione personale.', defaults: { fontSize: 1, lineHeight: 1.6, fontStyle: 'italic', color: '#0f172a', margin: { top: 1.2, bottom: 1.6, left: 1, right: 1 }, align: 'center' } },
+    ];
+
+    if (metaLabel) {
+        const label = strings.bookInfo ? strings.bookInfo.replace('%1$s', String(sampleFields.length)) : sampleFields.length + ' campi simulati';
+        metaLabel.textContent = label;
+    }
+
+    const baseStyle = {
+        fontSize: 1.1,
+        lineHeight: 1.55,
+        fontFamily: "'Georgia', serif",
+        fontStyle: 'normal',
+        fontWeight: '400',
+        hyphenate: false,
+        align: 'left',
+        color: '#1f2937',
+        backgroundColor: '#ffffff',
+        margin: { top: 0.6, right: 1, bottom: 0.6, left: 1 },
+        padding: { top: 0.8, right: 1, bottom: 0.8, left: 1 },
+    };
+
+    function cloneSpacing(spacing) {
+        return {
+            top: typeof spacing.top === 'number' ? spacing.top : 0,
+            right: typeof spacing.right === 'number' ? spacing.right : 0,
+            bottom: typeof spacing.bottom === 'number' ? spacing.bottom : 0,
+            left: typeof spacing.left === 'number' ? spacing.left : 0,
+        };
+    }
+
+    function mergeStyles(base, override) {
+        const style = Object.assign({}, base);
+        if (override) {
+            Object.keys(override).forEach(function (key) {
+                if (key === 'margin' || key === 'padding') {
+                    style[key] = cloneSpacing(style[key] || { top: 0, right: 0, bottom: 0, left: 0 });
+                    const value = override[key] || {};
+                    Object.keys(value).forEach(function (side) {
+                        const numeric = parseFloat(value[side]);
+                        if (!Number.isNaN(numeric)) {
+                            style[key][side] = numeric;
+                        }
+                    });
+                } else {
+                    style[key] = override[key];
+                }
+            });
         }
-    });
+        if (!style.margin) {
+            style.margin = cloneSpacing(base.margin || { top: 0, right: 0, bottom: 0, left: 0 });
+        }
+        if (!style.padding) {
+            style.padding = cloneSpacing(base.padding || { top: 0, right: 0, bottom: 0, left: 0 });
+        }
+        return style;
+    }
+
+    const fieldStyles = {};
+    const fieldNodes = {};
 
     const stage = new Konva.Stage({
         container: container,
-        width: container.clientWidth,
-        height: container.clientHeight,
+        width: BASE_WIDTH,
+        height: BASE_HEIGHT,
+        listening: true,
     });
 
-    const backgroundLayer = new Konva.Layer({ listening: false });
-    const pagesLayer = new Konva.Layer();
+    const backgroundLayer = new Konva.Layer({ listening: true });
+    const contentLayer = new Konva.Layer();
 
     stage.add(backgroundLayer);
-    stage.add(pagesLayer);
+    stage.add(contentLayer);
 
-    const emptyMessage = document.getElementById('bookcreator-epub-designer-empty');
-    const selector = document.getElementById('bookcreator-epub-designer-book');
-    const metaLabel = document.getElementById('bookcreator-epub-designer-book-meta');
-    const titleLabel = document.getElementById('bookcreator-epub-designer-selected-title');
-    const closeButton = document.querySelector('[data-epub-designer-close]');
+    const contentGroup = new Konva.Group({
+        x: 0,
+        y: 0,
+        listening: true,
+    });
 
-    let currentBookId = '';
-    let currentScrollY = 0;
-    let currentScrollBounds = { min: 0, max: 0 };
-    let selectableItems = [];
-    let activeHighlight = null;
-    let currentContentGroup = null;
-    let requestLayoutUpdate = null;
-    let lastTouchY = null;
+    contentLayer.add(contentGroup);
 
-    if (data.initialBookId && booksById[String(data.initialBookId)]) {
-        currentBookId = String(data.initialBookId);
-    } else if (booksArray[0] && typeof booksArray[0].id !== 'undefined') {
-        currentBookId = String(booksArray[0].id);
-    }
+    const pageBackground = new Konva.Rect({
+        x: 32,
+        y: 32,
+        width: BASE_WIDTH - 64,
+        height: BASE_HEIGHT - 64,
+        cornerRadius: 28,
+        fill: '#fdfcf8',
+        stroke: 'rgba(148, 163, 184, 0.35)',
+        strokeWidth: 1,
+        shadowColor: 'rgba(15, 23, 42, 0.25)',
+        shadowBlur: 42,
+        shadowOffsetY: 28,
+        shadowOpacity: 0.28,
+    });
 
-    if (selector && currentBookId) {
-        selector.value = String(currentBookId);
-    }
+    const backgroundGradient = new Konva.Rect({
+        x: 0,
+        y: 0,
+        width: BASE_WIDTH,
+        height: BASE_HEIGHT,
+        fillLinearGradientStartPoint: { x: 0, y: 0 },
+        fillLinearGradientEndPoint: { x: BASE_WIDTH, y: BASE_HEIGHT },
+        fillLinearGradientColorStops: [0, '#e0f2fe', 0.5, '#f1f5f9', 1, '#e2e8f0'],
+    });
 
-    const strings = Object.assign(
-        {
-            noBooks: '',
-            emptyValue: '',
-            bookInfo: '%1$s',
-            noPages: '',
-            indexBulletPrimary: '•',
-            indexBulletSecondary: '◦',
-        },
-        data.strings || {}
-    );
+    backgroundLayer.add(backgroundGradient);
+    backgroundLayer.add(pageBackground);
+    backgroundLayer.draw();
 
-    if (closeButton && data.closeUrl) {
-        closeButton.addEventListener('click', function (event) {
-            event.preventDefault();
-            window.location.href = data.closeUrl;
+    const sampleImage = new window.Image();
+    sampleImage.src = sampleImageSrc;
+
+    function createHighlightRect() {
+        return new Konva.Rect({
+            cornerRadius: 26,
+            stroke: '#2563eb',
+            strokeWidth: 2,
+            dash: [10, 6],
+            opacity: 0.9,
+            visible: false,
         });
     }
 
-    const fontFamily = 'Times New Roman, Times, serif';
-    const PAGE_PADDING_X = 48;
-    const ICON_RADIUS = 14;
-    const ICON_CENTER_X = ICON_RADIUS / 2;
-    const TOOLTIP_OFFSET_X = ICON_RADIUS * 2 + 18;
-    const TEXT_X = PAGE_PADDING_X + 48;
-    const BLOCK_SPACING = 18;
-
-    function clampScroll(value) {
-        if (!currentScrollBounds) {
-            return value;
+    function computeFontStyle(style) {
+        const weight = parseInt(style.fontWeight, 10);
+        const isBold = !Number.isNaN(weight) ? weight >= 600 : String(style.fontWeight).toLowerCase() === 'bold';
+        const isItalic = String(style.fontStyle).toLowerCase() === 'italic';
+        if (isBold && isItalic) {
+            return 'italic bold';
         }
-
-        const min = typeof currentScrollBounds.min === 'number' ? currentScrollBounds.min : 0;
-        const max = typeof currentScrollBounds.max === 'number' ? currentScrollBounds.max : 0;
-
-        if (value < min) {
-            return min;
+        if (isBold) {
+            return 'bold';
         }
-
-        if (value > max) {
-            return max;
+        if (isItalic) {
+            return 'italic';
         }
-
-        return value;
+        return 'normal';
     }
 
-    function fitStage() {
-        const { clientWidth, clientHeight } = container;
-        stage.width(clientWidth);
-        stage.height(clientHeight);
+    function getSpacingPx(value, fontSizePx, fallback) {
+        const numeric = typeof value === 'number' ? value : parseFloat(value);
+        const spacing = Number.isNaN(numeric) ? fallback : numeric;
+        return spacing * fontSizePx;
     }
 
-    function computeLayout() {
-        const width = stage.width();
-        const height = stage.height();
-        const stagePadding = Math.max(48, Math.round(width * 0.06));
-        const pageWidth = Math.min(760, width - stagePadding * 2);
-        const pageHeight = Math.max(520, height - stagePadding * 2);
-        const pageX = (width - pageWidth) / 2;
-
-        return {
-            stagePadding,
-            pageWidth,
-            pageHeight,
-            pageX,
-        };
+    function getStyle(fieldId) {
+        return fieldStyles[fieldId] || mergeStyles(baseStyle, null);
     }
 
-    function drawBackground(layout) {
-        backgroundLayer.destroyChildren();
-
-        const width = stage.width();
-        const height = stage.height();
-
-        backgroundLayer.add(
-            new Konva.Rect({
-                x: 0,
-                y: 0,
-                width,
-                height,
-                fillLinearGradientStartPoint: { x: 0, y: 0 },
-                fillLinearGradientEndPoint: { x: 0, y: height },
-                fillLinearGradientColorStops: [0, '#f4efe4', 1, '#e6ded0'],
-            })
-        );
-
-        backgroundLayer.add(
-            new Konva.Rect({
-                x: layout.pageX - 24,
-                y: layout.stagePadding - 24,
-                width: layout.pageWidth + 48,
-                height: layout.pageHeight + 48,
-                stroke: 'rgba(15, 23, 42, 0.08)',
-                strokeWidth: 1,
-                cornerRadius: 32,
-                shadowColor: 'rgba(15, 23, 42, 0.12)',
-                shadowBlur: 48,
-                shadowOffsetX: 0,
-                shadowOffsetY: 24,
-                shadowOpacity: 0.8,
-            })
-        );
-
-        backgroundLayer.draw();
+    const textControlElements = [];
+    if (toolbar) {
+        toolbar.querySelectorAll('[data-text-control]').forEach(function (element) {
+            const group = element.closest('.bookcreator-epub-toolbar__group') || element;
+            if (textControlElements.indexOf(group) === -1) {
+                textControlElements.push(group);
+            }
+        });
     }
 
-    function toggleEmptyState(visible, message) {
-        if (!emptyMessage) {
+    function toggleTextControls(disabled) {
+        if (!toolbar) {
             return;
         }
-
-        if (visible) {
-            const content = typeof message === 'string' ? message : strings.noBooks;
-
-            if (content) {
-                emptyMessage.classList.add('is-visible');
-                emptyMessage.textContent = content;
+        const controls = toolbar.querySelectorAll('[data-text-control]');
+        controls.forEach(function (control) {
+            if ('disabled' in control) {
+                control.disabled = disabled;
+            }
+        });
+        textControlElements.forEach(function (element) {
+            if (disabled) {
+                element.classList.add('is-disabled');
             } else {
-                emptyMessage.classList.remove('is-visible');
-                emptyMessage.textContent = '';
+                element.classList.remove('is-disabled');
+            }
+        });
+    }
+
+    sampleFields.forEach(function (field) {
+        const style = mergeStyles(baseStyle, field.defaults || {});
+        fieldStyles[field.id] = style;
+
+        const group = new Konva.Group({
+            id: field.id,
+            name: 'bookcreator-epub-field',
+            listening: true,
+        });
+
+        const highlight = createHighlightRect();
+        const background = new Konva.Rect({
+            cornerRadius: 24,
+            stroke: 'rgba(148, 163, 184, 0.35)',
+            strokeWidth: 1,
+            fill: style.backgroundColor || '#ffffff',
+            shadowColor: 'rgba(15, 23, 42, 0.12)',
+            shadowBlur: 14,
+            shadowOpacity: 0.18,
+            shadowOffsetY: 6,
+        });
+
+        const label = new Konva.Text({
+            text: (field.label || '').toUpperCase(),
+            fontFamily: 'Inter, "Segoe UI", sans-serif',
+            fontSize: 12,
+            letterSpacing: 1,
+            fill: 'rgba(15, 23, 42, 0.6)',
+            listening: false,
+        });
+
+        let textNode = null;
+        let imageNode = null;
+
+        if (field.type === 'image') {
+            imageNode = new Konva.Image({ listening: false });
+            if (sampleImage.complete) {
+                imageNode.image(sampleImage);
+            } else {
+                sampleImage.addEventListener('load', function () {
+                    imageNode.image(sampleImage);
+                    layoutFields();
+                    contentLayer.batchDraw();
+                });
             }
         } else {
-            emptyMessage.classList.remove('is-visible');
-            emptyMessage.textContent = '';
-        }
-    }
-
-    function getBook(bookId) {
-        if (!bookId) {
-            return null;
-        }
-
-        return booksById[String(bookId)] || null;
-    }
-
-    function getBookPages(book) {
-        if (!book) {
-            return [];
-        }
-
-        return Array.isArray(book.pages) ? book.pages : [];
-    }
-
-    function getSequentialBlocks(book) {
-        const pages = getBookPages(book);
-        const blocks = [];
-
-        pages.forEach(function (page) {
-            if (!page || !Array.isArray(page.blocks)) {
-                return;
-            }
-
-            page.blocks.forEach(function (block) {
-                if (!block) {
-                    return;
-                }
-
-                blocks.push(block);
+            textNode = new Konva.Text({
+                text: field.text || '',
+                fontFamily: style.fontFamily || baseStyle.fontFamily,
+                fontSize: Math.max(10, style.fontSize * 16),
+                lineHeight: style.lineHeight || baseStyle.lineHeight,
+                fill: style.color || baseStyle.color,
+                align: style.align || 'left',
+                listening: false,
+                wrap: style.hyphenate ? 'char' : 'word',
             });
-        });
-
-        return blocks;
-    }
-
-    function isBlockVisible(block) {
-        if (!block) {
-            return false;
         }
 
-        if (block.type === 'image') {
-            return Boolean(block.url);
+        group.add(highlight);
+        group.add(background);
+        group.add(label);
+        if (textNode) {
+            group.add(textNode);
         }
-
-        return Boolean(formatFieldValue(block));
-    }
-
-    function countVisibleBlocks(book) {
-        const blocks = getSequentialBlocks(book);
-
-        return blocks.reduce(function (total, block) {
-            return total + (isBlockVisible(block) ? 1 : 0);
-        }, 0);
-    }
-
-    function formatIndexValue(block) {
-        if (!block || !block.value) {
-            return '';
+        if (imageNode) {
+            group.add(imageNode);
         }
-
-        try {
-            const items = JSON.parse(block.value);
-            if (!Array.isArray(items) || !items.length) {
-                return '';
-            }
-
-            return items
-                .map((item) => {
-                    if (!item || typeof item.text !== 'string' || !item.text.trim()) {
-                        return '';
-                    }
-                    const level = typeof item.level === 'number' ? item.level : 0;
-                    const bullet = level > 0 ? strings.indexBulletSecondary : strings.indexBulletPrimary;
-                    const indent = level > 0 ? '    '.repeat(level) : '';
-
-                    return indent + bullet + ' ' + item.text.trim();
-                })
-                .filter(Boolean)
-                .join('\n');
-        } catch (error) {
-            return '';
-        }
-    }
-
-    function formatFieldValue(block) {
-        if (!block) {
-            return strings.emptyValue;
-        }
-
-        if (block.format === 'index') {
-            return formatIndexValue(block);
-        }
-
-        const rawValue = typeof block.value === 'string' ? block.value : block && block.value != null ? String(block.value) : '';
-        const trimmedValue = rawValue.trim();
-
-        return trimmedValue;
-    }
-
-    function createInfoIcon(label) {
-        const icon = new Konva.Group({ listening: true });
-        const circle = new Konva.Circle({
-            radius: 14,
-            stroke: '#0d7a36',
-            strokeWidth: 1,
-            fill: '#16a34a',
-            shadowColor: 'rgba(0, 0, 0, 0.18)',
-            shadowBlur: 6,
-            shadowOpacity: 0.6,
-            shadowOffsetX: 0,
-            shadowOffsetY: 2,
-        });
-        icon.add(circle);
-        icon.add(
-            new Konva.Text({
-                text: 'i',
-                fontFamily,
-                fontSize: 14,
-                fill: '#ffffff',
-                fontStyle: '700',
-                x: -3.4,
-                y: -7.2,
-            })
-        );
-
-        const tooltip = new Konva.Label({
-            visible: false,
-            listening: false,
-            opacity: 0.94,
-        });
-
-        tooltip.add(
-            new Konva.Tag({
-                fill: '#0f172a',
-                pointerDirection: 'left',
-                pointerWidth: 8,
-                pointerHeight: 8,
-                cornerRadius: 2,
-            })
-        );
-
-        tooltip.add(
-            new Konva.Text({
-                text: label || '',
-                fontFamily,
-                fontSize: 12,
-                fill: '#ffffff',
-                padding: 6,
-            })
-        );
-
-        return { icon, tooltip };
-    }
-
-    function attachTooltip(node, tooltip) {
-        if (!node || !tooltip) {
-            return;
-        }
-
-        const showTooltip = function () {
-            tooltip.visible(true);
-            container.style.cursor = 'help';
-            pagesLayer.batchDraw();
-        };
-
-        const hideTooltip = function () {
-            tooltip.visible(false);
-            container.style.cursor = 'default';
-            pagesLayer.batchDraw();
-        };
-
-        node.on('mouseenter', showTooltip);
-        node.on('mouseleave', hideTooltip);
-        node.on('touchstart', function () {
-            tooltip.visible(!tooltip.visible());
-            pagesLayer.batchDraw();
-        });
-    }
-
-    function registerSelectable(group, highlight) {
-        if (!group) {
-            return;
-        }
-
-        selectableItems.push({ group: group, highlight: highlight || null });
-
-        const activate = function () {
-            selectableItems.forEach(function (item) {
-                if (item.highlight && item.highlight !== highlight) {
-                    item.highlight.visible(false);
-                }
-            });
-
-            if (highlight) {
-                const nextState = !highlight.visible();
-                selectableItems.forEach(function (item) {
-                    if (item.highlight) {
-                        item.highlight.visible(false);
-                    }
-                });
-                highlight.visible(nextState);
-                activeHighlight = nextState ? highlight : null;
-            } else {
-                activeHighlight = null;
-            }
-
-            pagesLayer.batchDraw();
-        };
 
         group.on('mouseenter', function () {
             container.style.cursor = 'pointer';
         });
-
         group.on('mouseleave', function () {
             container.style.cursor = 'default';
         });
-
-        group.on('click tap', activate);
-
-        if (highlight) {
-            highlight.visible(false);
-        }
-    }
-
-    function buildFieldGroup(block, layout, baseY) {
-        const value = formatFieldValue(block);
-
-        if (!value) {
-            return null;
-        }
-
-        const group = new Konva.Group({
-            x: 0,
-            y: baseY,
-            listening: true,
+        group.on('click tap', function (event) {
+            event.cancelBubble = true;
+            selectField(field.id);
         });
 
-        const highlight = new Konva.Rect({
-            x: TEXT_X - 28,
-            y: -12,
-            width: layout.pageWidth - TEXT_X - PAGE_PADDING_X + 56,
-            height: 0,
-            cornerRadius: 14,
-            fill: 'rgba(148, 163, 184, 0.22)',
-            visible: false,
-        });
-        group.add(highlight);
-
-        const info = createInfoIcon(block.label || '');
-        info.icon.x(ICON_CENTER_X);
-        info.tooltip.x(TOOLTIP_OFFSET_X);
-        info.tooltip.y(-18);
-        group.add(info.icon);
-        group.add(info.tooltip);
-
-        const valueText = new Konva.Text({
-            x: TEXT_X,
-            y: 0,
-            text: value,
-            fontFamily,
-            fontSize: 18,
-            lineHeight: 1.6,
-            fill: '#0f172a',
-            width: layout.pageWidth - TEXT_X - PAGE_PADDING_X,
-        });
-
-        group.add(valueText);
-
-        info.icon.y(valueText.y() + 16);
-        info.tooltip.y(valueText.y() - 18);
-
-        highlight.height(valueText.height() + 24);
-
-        attachTooltip(info.icon, info.tooltip);
-        attachTooltip(valueText, info.tooltip);
-
-        return {
-            group,
-            highlight,
-            getHeight: function () {
-                return valueText.height() + BLOCK_SPACING;
-            },
+        fieldNodes[field.id] = {
+            field: field,
+            group: group,
+            highlight: highlight,
+            background: background,
+            label: label,
+            text: textNode,
+            image: imageNode,
         };
-    }
 
-    function buildImageGroup(block, layout, baseY) {
-        if (!block.url) {
-            return null;
-        }
+        contentGroup.add(group);
+    });
 
-        const group = new Konva.Group({
-            x: 0,
-            y: baseY,
-            listening: true,
-        });
+    let scrollBounds = { min: 0, max: 0 };
+    let scrollY = 0;
+    let lastTouchY = null;
 
-        const highlight = new Konva.Rect({
-            x: TEXT_X - 28,
-            y: -12,
-            width: layout.pageWidth - TEXT_X - PAGE_PADDING_X + 56,
-            height: 0,
-            cornerRadius: 14,
-            fill: 'rgba(148, 163, 184, 0.22)',
-            visible: false,
-        });
-        group.add(highlight);
+    function layoutFields() {
+        let cursorY = PAGE_PADDING_TOP;
+        const pageWidth = BASE_WIDTH - PAGE_PADDING_X * 2;
 
-        const info = createInfoIcon(block.label || '');
-        info.icon.x(ICON_CENTER_X);
-        info.tooltip.x(TOOLTIP_OFFSET_X);
-        info.tooltip.y(-18);
-        group.add(info.icon);
-        group.add(info.tooltip);
+        sampleFields.forEach(function (field) {
+            const nodes = fieldNodes[field.id];
+            if (!nodes) {
+                return;
+            }
+            const style = getStyle(field.id);
+            const fontSizePx = Math.max(10, (style.fontSize || baseStyle.fontSize) * 16);
+            const lineHeight = style.lineHeight || baseStyle.lineHeight;
+            const marginTop = getSpacingPx(style.margin.top, fontSizePx, baseStyle.margin.top);
+            const marginRight = getSpacingPx(style.margin.right, fontSizePx, baseStyle.margin.right);
+            const marginBottom = getSpacingPx(style.margin.bottom, fontSizePx, baseStyle.margin.bottom);
+            const marginLeft = getSpacingPx(style.margin.left, fontSizePx, baseStyle.margin.left);
+            const paddingTop = getSpacingPx(style.padding.top, fontSizePx, baseStyle.padding.top);
+            const paddingRight = getSpacingPx(style.padding.right, fontSizePx, baseStyle.padding.right);
+            const paddingBottom = getSpacingPx(style.padding.bottom, fontSizePx, baseStyle.padding.bottom);
+            const paddingLeft = getSpacingPx(style.padding.left, fontSizePx, baseStyle.padding.left);
 
-        const availableWidth = layout.pageWidth - TEXT_X - PAGE_PADDING_X;
-        const maxHeight = Math.min(320, layout.pageHeight * 0.6);
-        const frame = new Konva.Rect({
-            x: TEXT_X,
-            y: 0,
-            width: availableWidth,
-            height: maxHeight,
-            stroke: 'rgba(100, 116, 139, 0.55)',
-            strokeWidth: 1,
-            dash: [5, 5],
-            cornerRadius: 12,
-            listening: false,
-        });
-        const imageNode = new Konva.Image({
-            x: TEXT_X,
-            y: 0,
-            listening: false,
-        });
+            const levelOffset = (field.level || 0) * 36;
+            const containerX = PAGE_PADDING_X + levelOffset + marginLeft;
+            const containerWidth = pageWidth - levelOffset - marginLeft - marginRight;
 
-        group.add(frame);
-        group.add(imageNode);
+            nodes.label.x(containerX);
+            nodes.label.y(cursorY + marginTop);
+            nodes.label.fontSize(Math.max(11, fontSizePx * 0.55));
+            nodes.label.opacity(0.68);
+            nodes.label.width(containerWidth);
+            nodes.label.align('left');
 
-        highlight.height(maxHeight + 32);
-        info.icon.y(20);
+            let blockY = nodes.label.y() + nodes.label.height() + 6;
+            let contentHeight = 0;
 
-        let computedHeight = maxHeight + BLOCK_SPACING;
+            nodes.background.x(containerX);
+            nodes.background.y(blockY);
+            nodes.background.width(containerWidth);
+            nodes.background.fill(style.backgroundColor || '#ffffff');
 
-        const image = new window.Image();
+            if (nodes.text) {
+                const textNode = nodes.text;
+                textNode.text(field.text || '');
+                textNode.fontFamily(style.fontFamily || baseStyle.fontFamily);
+                textNode.fontSize(fontSizePx);
+                textNode.lineHeight(lineHeight);
+                textNode.fill(style.color || baseStyle.color);
+                textNode.align(style.align || 'left');
+                textNode.wrap(style.hyphenate ? 'char' : 'word');
+                textNode.fontStyle(computeFontStyle(style));
 
-        image.onload = function () {
-            const scale = Math.min(availableWidth / image.width, maxHeight / image.height, 1);
-            const displayWidth = image.width * scale;
-            const displayHeight = image.height * scale;
+                const contentWidth = Math.max(32, containerWidth - paddingLeft - paddingRight);
+                textNode.width(contentWidth);
+                textNode.x(containerX + paddingLeft);
+                textNode.y(blockY + paddingTop);
 
-            imageNode.image(image);
-            imageNode.width(displayWidth);
-            imageNode.height(displayHeight);
-            imageNode.x(TEXT_X + (availableWidth - displayWidth) / 2);
-            imageNode.y((maxHeight - displayHeight) / 2);
+                contentHeight = textNode.height();
+                nodes.background.height(contentHeight + paddingTop + paddingBottom);
+                nodes.highlight.width(nodes.background.width());
+                nodes.highlight.height(nodes.background.height());
+                nodes.highlight.x(nodes.background.x());
+                nodes.highlight.y(nodes.background.y());
+            } else if (nodes.image) {
+                const imageNode = nodes.image;
+                const image = imageNode.image();
+                const maxHeight = typeof field.imageMaxHeight === 'number' ? field.imageMaxHeight : 220;
+                const contentWidth = Math.max(64, containerWidth - paddingLeft - paddingRight);
 
-            frame.width(displayWidth + 40);
-            frame.height(displayHeight + 40);
-            frame.x(TEXT_X + (availableWidth - frame.width()) / 2);
-            frame.y(imageNode.y() - 20);
+                if (image && image.width && image.height) {
+                    const scale = Math.min(contentWidth / image.width, maxHeight / image.height, 1);
+                    const displayWidth = image.width * scale;
+                    const displayHeight = image.height * scale;
+                    imageNode.width(displayWidth);
+                    imageNode.height(displayHeight);
+                    imageNode.x(containerX + paddingLeft + (contentWidth - displayWidth) / 2);
+                    imageNode.y(blockY + paddingTop + (maxHeight - displayHeight) / 2);
+                    contentHeight = Math.max(displayHeight, maxHeight);
+                } else {
+                    imageNode.width(contentWidth * 0.6);
+                    imageNode.height(maxHeight * 0.6);
+                    imageNode.x(containerX + paddingLeft + contentWidth * 0.2);
+                    imageNode.y(blockY + paddingTop + maxHeight * 0.2);
+                    contentHeight = maxHeight;
+                }
 
-            info.icon.y(frame.y() + 20);
-            info.tooltip.y(frame.y() - 18);
-
-            highlight.height(frame.height() + 32);
-
-            computedHeight = frame.y() + frame.height() + BLOCK_SPACING;
-
-            if (typeof requestLayoutUpdate === 'function') {
-                requestLayoutUpdate();
+                nodes.background.height(contentHeight + paddingTop + paddingBottom);
+                nodes.highlight.width(nodes.background.width());
+                nodes.highlight.height(nodes.background.height());
+                nodes.highlight.x(nodes.background.x());
+                nodes.highlight.y(nodes.background.y());
             }
 
-            pagesLayer.batchDraw();
+            cursorY = nodes.background.y() + nodes.background.height() + marginBottom;
+        });
+
+        const totalHeight = cursorY;
+        const minOffset = Math.min(0, BASE_HEIGHT - PAGE_PADDING_TOP - totalHeight);
+        scrollBounds = {
+            min: minOffset,
+            max: 0,
         };
+        scrollY = Math.max(Math.min(scrollY, scrollBounds.max), scrollBounds.min);
+        contentGroup.y(scrollY);
 
-        image.onerror = function () {
-            group.destroy();
-            if (typeof requestLayoutUpdate === 'function') {
-                requestLayoutUpdate();
-            }
-            pagesLayer.batchDraw();
-        };
-
-        image.src = block.url;
-
-        attachTooltip(info.icon, info.tooltip);
-
-        return {
-            group,
-            highlight,
-            getHeight: function () {
-                return computedHeight;
-            },
-        };
+        contentLayer.batchDraw();
     }
 
-    function createBookView(book, layout) {
-        const wrapper = new Konva.Group({
-            x: layout.pageX,
-            y: layout.stagePadding,
-            width: layout.pageWidth,
-            height: layout.pageHeight,
-            clip: {
-                x: 0,
-                y: 0,
-                width: layout.pageWidth,
-                height: layout.pageHeight,
-            },
-        });
+    layoutFields();
 
-        const background = new Konva.Rect({
-            x: 0,
-            y: 0,
-            width: layout.pageWidth,
-            height: layout.pageHeight,
-            fill: '#fbfaf5',
-            stroke: 'rgba(30, 41, 59, 0.28)',
-            strokeWidth: 1,
-            cornerRadius: 18,
-            listening: false,
-            shadowColor: 'rgba(15, 23, 42, 0.22)',
-            shadowBlur: 36,
-            shadowOpacity: 0.35,
-            shadowOffsetX: 0,
-            shadowOffsetY: 26,
-        });
-
-        const contentGroup = new Konva.Group({
-            x: 0,
-            y: 0,
-            listening: true,
-        });
-
-        wrapper.add(background);
-        wrapper.add(contentGroup);
-
-        const layoutBlocks = function () {
-            const totalHeight = PAGE_PADDING_X * 2;
-
-            background.height(Math.max(layout.pageHeight, totalHeight));
-
-            currentScrollBounds = {
-                min: 0,
-                max: 0,
-            };
-
-            contentGroup.y(0);
-
-            requestLayoutUpdate = layoutBlocks;
-        };
-
-        layoutBlocks();
-
-        return {
-            group: wrapper,
-            content: contentGroup,
-        };
-    }
-
-    stage.on('wheel', function (event) {
-        if (!currentContentGroup) {
+    function fitStage() {
+        const width = container.offsetWidth;
+        const height = container.offsetHeight;
+        if (!width || !height) {
             return;
         }
+        const scale = Math.min(width / BASE_WIDTH, height / BASE_HEIGHT);
+        stage.width(BASE_WIDTH);
+        stage.height(BASE_HEIGHT);
+        stage.scale({ x: scale, y: scale });
+        stage.batchDraw();
+    }
 
-        if (event.evt && typeof event.evt.preventDefault === 'function') {
-            event.evt.preventDefault();
+    fitStage();
+    window.requestAnimationFrame(fitStage);
+    window.addEventListener('resize', Konva.Util.throttle(fitStage, 100));
+
+    let selectedFieldId = null;
+
+    function showToolbar() {
+        if (!toolbar) {
+            return;
+        }
+        toolbar.classList.remove('is-hidden');
+        toolbar.setAttribute('aria-hidden', 'false');
+    }
+
+    function hideToolbar() {
+        if (!toolbar) {
+            return;
+        }
+        toolbar.classList.add('is-hidden');
+        toolbar.setAttribute('aria-hidden', 'true');
+    }
+
+    function updateAlignButtons(activeAlign) {
+        if (!toolbar) {
+            return;
+        }
+        toolbar.querySelectorAll('[data-epub-align]').forEach(function (button) {
+            if (button.dataset.epubAlign === activeAlign) {
+                button.classList.add('is-active');
+            } else {
+                button.classList.remove('is-active');
+            }
+        });
+    }
+
+    function updateHyphenationButton(active) {
+        if (!toolbar) {
+            return;
+        }
+        const button = toolbar.querySelector('[data-epub-control="hyphenate"]');
+        if (!button) {
+            return;
+        }
+        if (active) {
+            button.classList.add('is-active');
+            button.textContent = 'Attivo';
+        } else {
+            button.classList.remove('is-active');
+            button.textContent = 'Attiva';
+        }
+    }
+
+    function populateToolbar(fieldId) {
+        if (!toolbar) {
+            return;
+        }
+        const style = getStyle(fieldId);
+        const nodes = fieldNodes[fieldId];
+        if (!nodes) {
+            return;
+        }
+        const field = nodes.field;
+        if (toolbarFieldLabel) {
+            toolbarFieldLabel.textContent = field.label || fieldId;
+        }
+        const fontSizeInput = toolbar.querySelector('[data-epub-control="font-size"]');
+        const lineHeightInput = toolbar.querySelector('[data-epub-control="line-height"]');
+        const fontFamilySelect = toolbar.querySelector('[data-epub-control="font-family"]');
+        const fontStyleSelect = toolbar.querySelector('[data-epub-control="font-style"]');
+        const fontWeightSelect = toolbar.querySelector('[data-epub-control="font-weight"]');
+        const colorInput = toolbar.querySelector('[data-epub-control="color"]');
+        const backgroundInput = toolbar.querySelector('[data-epub-control="background-color"]');
+        const marginTopInput = toolbar.querySelector('[data-epub-control="margin-top"]');
+        const marginRightInput = toolbar.querySelector('[data-epub-control="margin-right"]');
+        const marginBottomInput = toolbar.querySelector('[data-epub-control="margin-bottom"]');
+        const marginLeftInput = toolbar.querySelector('[data-epub-control="margin-left"]');
+        const paddingTopInput = toolbar.querySelector('[data-epub-control="padding-top"]');
+        const paddingRightInput = toolbar.querySelector('[data-epub-control="padding-right"]');
+        const paddingBottomInput = toolbar.querySelector('[data-epub-control="padding-bottom"]');
+        const paddingLeftInput = toolbar.querySelector('[data-epub-control="padding-left"]');
+
+        if (fontSizeInput) {
+            fontSizeInput.value = (Math.round((style.fontSize || baseStyle.fontSize) * 100) / 100).toFixed(2);
+        }
+        if (lineHeightInput) {
+            lineHeightInput.value = (Math.round((style.lineHeight || baseStyle.lineHeight) * 100) / 100).toFixed(2);
+        }
+        if (fontFamilySelect) {
+            fontFamilySelect.value = style.fontFamily || baseStyle.fontFamily;
+        }
+        if (fontStyleSelect) {
+            fontStyleSelect.value = style.fontStyle || baseStyle.fontStyle;
+        }
+        if (fontWeightSelect) {
+            fontWeightSelect.value = style.fontWeight || baseStyle.fontWeight;
+        }
+        if (colorInput) {
+            colorInput.value = style.color || baseStyle.color;
+        }
+        if (backgroundInput) {
+            backgroundInput.value = style.backgroundColor || baseStyle.backgroundColor;
+        }
+        if (marginTopInput) {
+            marginTopInput.value = (Math.round(style.margin.top * 100) / 100).toFixed(2);
+        }
+        if (marginRightInput) {
+            marginRightInput.value = (Math.round(style.margin.right * 100) / 100).toFixed(2);
+        }
+        if (marginBottomInput) {
+            marginBottomInput.value = (Math.round(style.margin.bottom * 100) / 100).toFixed(2);
+        }
+        if (marginLeftInput) {
+            marginLeftInput.value = (Math.round(style.margin.left * 100) / 100).toFixed(2);
+        }
+        if (paddingTopInput) {
+            paddingTopInput.value = (Math.round(style.padding.top * 100) / 100).toFixed(2);
+        }
+        if (paddingRightInput) {
+            paddingRightInput.value = (Math.round(style.padding.right * 100) / 100).toFixed(2);
+        }
+        if (paddingBottomInput) {
+            paddingBottomInput.value = (Math.round(style.padding.bottom * 100) / 100).toFixed(2);
+        }
+        if (paddingLeftInput) {
+            paddingLeftInput.value = (Math.round(style.padding.left * 100) / 100).toFixed(2);
         }
 
-        const delta = event.evt && typeof event.evt.deltaY === 'number' ? event.evt.deltaY : 0;
+        const isImage = field.type === 'image';
+        toggleTextControls(isImage);
 
+        updateAlignButtons(style.align || 'left');
+        updateHyphenationButton(Boolean(style.hyphenate));
+    }
+
+    function selectField(fieldId) {
+        if (!fieldNodes[fieldId]) {
+            return;
+        }
+        Object.keys(fieldNodes).forEach(function (id) {
+            const node = fieldNodes[id];
+            if (node.highlight) {
+                node.highlight.visible(id === fieldId);
+            }
+        });
+        selectedFieldId = fieldId;
+        populateToolbar(fieldId);
+        showToolbar();
+        contentLayer.batchDraw();
+    }
+
+    function deselectField() {
+        Object.keys(fieldNodes).forEach(function (id) {
+            const node = fieldNodes[id];
+            if (node.highlight) {
+                node.highlight.visible(false);
+            }
+        });
+        selectedFieldId = null;
+        hideToolbar();
+        contentLayer.batchDraw();
+    }
+
+    stage.on('click tap', function (event) {
+        if (event.target === stage || event.target === pageBackground) {
+            deselectField();
+        }
+    });
+
+    stage.on('wheel', function (event) {
+        if (!event.evt) {
+            return;
+        }
+        if (typeof event.evt.preventDefault === 'function') {
+            event.evt.preventDefault();
+        }
+        const delta = event.evt.deltaY;
         if (!delta) {
             return;
         }
-
-        currentScrollY = clampScroll(currentScrollY - delta);
-        currentContentGroup.y(currentScrollY);
-        pagesLayer.batchDraw();
+        scrollY = Math.max(Math.min(scrollY - delta, scrollBounds.max), scrollBounds.min);
+        contentGroup.y(scrollY);
+        contentLayer.batchDraw();
     });
 
     stage.on('touchstart', function (event) {
         const touches = event.evt && event.evt.touches ? event.evt.touches : null;
-
         if (touches && touches.length) {
             lastTouchY = touches[0].clientY;
         }
     });
 
     stage.on('touchmove', function (event) {
-        if (!currentContentGroup) {
-            return;
-        }
-
         const touches = event.evt && event.evt.touches ? event.evt.touches : null;
-
         if (!touches || !touches.length) {
             return;
         }
-
         const currentY = touches[0].clientY;
-
         if (lastTouchY == null) {
             lastTouchY = currentY;
             return;
         }
-
         const delta = lastTouchY - currentY;
         lastTouchY = currentY;
-
         if (!delta) {
             return;
         }
-
-        currentScrollY = clampScroll(currentScrollY - delta);
-        currentContentGroup.y(currentScrollY);
-        pagesLayer.batchDraw();
+        scrollY = Math.max(Math.min(scrollY - delta, scrollBounds.max), scrollBounds.min);
+        contentGroup.y(scrollY);
+        contentLayer.batchDraw();
     });
 
     stage.on('touchend touchcancel', function () {
         lastTouchY = null;
     });
 
-
-    function updateToolbar(bookId) {
-        const book = getBook(bookId);
-
-        if (titleLabel) {
-            titleLabel.textContent = book ? book.title : '';
-        }
-
-        if (metaLabel) {
-            const count = book ? countVisibleBlocks(book) : 0;
-            metaLabel.textContent = book ? strings.bookInfo.replace('%1$s', String(count)) : '';
-        }
-    }
-
-    function renderBook(bookId, layout) {
-        pagesLayer.destroyChildren();
-
-        const book = getBook(bookId);
-
-        if (!bookId || !book) {
-            toggleEmptyState(true, strings.noBooks);
-            currentContentGroup = null;
-            currentScrollBounds = { min: 0, max: 0 };
-            currentScrollY = 0;
-            selectableItems = [];
-            activeHighlight = null;
-            requestLayoutUpdate = null;
-            lastTouchY = null;
-            pagesLayer.draw();
-            return;
-        }
-
-        toggleEmptyState(false);
-
-        selectableItems = [];
-        activeHighlight = null;
-        requestLayoutUpdate = null;
-        lastTouchY = null;
-
-        const view = createBookView(book, layout);
-
-        currentContentGroup = view.content;
-        currentScrollY = clampScroll(currentScrollY);
-        currentContentGroup.y(currentScrollY);
-
-        pagesLayer.add(view.group);
-        pagesLayer.draw();
-    }
-
-    function refresh() {
-        fitStage();
-        const layout = computeLayout();
-        drawBackground(layout);
-        renderBook(currentBookId, layout);
-    }
-
-    if (selector) {
-        selector.addEventListener('change', function (event) {
-            const value = event.target.value;
-            currentBookId = value && booksById[String(value)] ? String(value) : '';
-            currentScrollY = 0;
-            lastTouchY = null;
-            updateToolbar(currentBookId);
-            refresh();
+    if (closeToolbarButton) {
+        closeToolbarButton.addEventListener('click', function () {
+            deselectField();
         });
     }
 
-    updateToolbar(currentBookId);
-    refresh();
+    function updateStyle(fieldId, updater) {
+        const style = getStyle(fieldId);
+        updater(style);
+        layoutFields();
+    }
 
-    const throttledResize = Konva.Util.throttle(function () {
-        refresh();
-    }, 200);
+    function parsePositive(value, fallback) {
+        const numeric = parseFloat(value);
+        if (Number.isNaN(numeric) || numeric < 0) {
+            return fallback;
+        }
+        return numeric;
+    }
 
-    window.addEventListener('resize', throttledResize);
+    if (toolbar) {
+        toolbar.querySelectorAll('[data-step-control]').forEach(function (button) {
+            button.addEventListener('click', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const control = button.dataset.stepControl;
+                const step = parseFloat(button.dataset.step || '0');
+                const input = toolbar.querySelector('[data-epub-control="' + control + '"]');
+                if (!input) {
+                    return;
+                }
+                const min = parseFloat(input.min || '0');
+                const max = parseFloat(input.max || '100');
+                let current = parseFloat(input.value || '0');
+                if (Number.isNaN(current)) {
+                    current = min || 0;
+                }
+                let nextValue = current + step;
+                if (!Number.isNaN(min)) {
+                    nextValue = Math.max(min, nextValue);
+                }
+                if (!Number.isNaN(max)) {
+                    nextValue = Math.min(max, nextValue);
+                }
+                input.value = (Math.round(nextValue * 100) / 100).toFixed(2);
+                input.dispatchEvent(new Event('change', { bubbles: true }));
+            });
+        });
+
+        const fontSizeInput = toolbar.querySelector('[data-epub-control="font-size"]');
+        if (fontSizeInput) {
+            fontSizeInput.addEventListener('change', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = parsePositive(fontSizeInput.value, baseStyle.fontSize);
+                fontSizeInput.value = (Math.round(value * 100) / 100).toFixed(2);
+                updateStyle(selectedFieldId, function (style) {
+                    style.fontSize = value;
+                });
+            });
+        }
+
+        const lineHeightInput = toolbar.querySelector('[data-epub-control="line-height"]');
+        if (lineHeightInput) {
+            lineHeightInput.addEventListener('change', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = parsePositive(lineHeightInput.value, baseStyle.lineHeight);
+                lineHeightInput.value = (Math.round(value * 100) / 100).toFixed(2);
+                updateStyle(selectedFieldId, function (style) {
+                    style.lineHeight = value;
+                });
+            });
+        }
+
+        const fontFamilySelect = toolbar.querySelector('[data-epub-control="font-family"]');
+        if (fontFamilySelect) {
+            fontFamilySelect.addEventListener('change', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = fontFamilySelect.value || baseStyle.fontFamily;
+                updateStyle(selectedFieldId, function (style) {
+                    style.fontFamily = value;
+                });
+            });
+        }
+
+        const fontStyleSelect = toolbar.querySelector('[data-epub-control="font-style"]');
+        if (fontStyleSelect) {
+            fontStyleSelect.addEventListener('change', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = fontStyleSelect.value || baseStyle.fontStyle;
+                updateStyle(selectedFieldId, function (style) {
+                    style.fontStyle = value;
+                });
+            });
+        }
+
+        const fontWeightSelect = toolbar.querySelector('[data-epub-control="font-weight"]');
+        if (fontWeightSelect) {
+            fontWeightSelect.addEventListener('change', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = fontWeightSelect.value || baseStyle.fontWeight;
+                updateStyle(selectedFieldId, function (style) {
+                    style.fontWeight = value;
+                });
+            });
+        }
+
+        const colorInput = toolbar.querySelector('[data-epub-control="color"]');
+        if (colorInput) {
+            colorInput.addEventListener('input', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = colorInput.value || baseStyle.color;
+                updateStyle(selectedFieldId, function (style) {
+                    style.color = value;
+                });
+            });
+        }
+
+        const backgroundInput = toolbar.querySelector('[data-epub-control="background-color"]');
+        if (backgroundInput) {
+            backgroundInput.addEventListener('input', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = backgroundInput.value || baseStyle.backgroundColor;
+                updateStyle(selectedFieldId, function (style) {
+                    style.backgroundColor = value;
+                });
+            });
+        }
+
+        toolbar.querySelectorAll('[data-epub-align]').forEach(function (button) {
+            button.addEventListener('click', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const align = button.dataset.epubAlign || 'left';
+                updateStyle(selectedFieldId, function (style) {
+                    style.align = align;
+                });
+                updateAlignButtons(align);
+            });
+        });
+
+        const hyphenateButton = toolbar.querySelector('[data-epub-control="hyphenate"]');
+        if (hyphenateButton) {
+            hyphenateButton.addEventListener('click', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                updateStyle(selectedFieldId, function (style) {
+                    style.hyphenate = !style.hyphenate;
+                    updateHyphenationButton(style.hyphenate);
+                });
+            });
+        }
+
+        const marginControls = ['margin-top', 'margin-right', 'margin-bottom', 'margin-left'];
+        marginControls.forEach(function (control) {
+            const input = toolbar.querySelector('[data-epub-control="' + control + '"]');
+            if (!input) {
+                return;
+            }
+            input.addEventListener('change', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = parsePositive(input.value, baseStyle.margin.top);
+                input.value = (Math.round(value * 100) / 100).toFixed(2);
+                const key = control.split('-')[1];
+                updateStyle(selectedFieldId, function (style) {
+                    style.margin[key] = value;
+                });
+            });
+        });
+
+        const paddingControls = ['padding-top', 'padding-right', 'padding-bottom', 'padding-left'];
+        paddingControls.forEach(function (control) {
+            const input = toolbar.querySelector('[data-epub-control="' + control + '"]');
+            if (!input) {
+                return;
+            }
+            input.addEventListener('change', function () {
+                if (!selectedFieldId) {
+                    return;
+                }
+                const value = parsePositive(input.value, baseStyle.padding.top);
+                input.value = (Math.round(value * 100) / 100).toFixed(2);
+                const key = control.split('-')[1];
+                updateStyle(selectedFieldId, function (style) {
+                    style.padding[key] = value;
+                });
+            });
+        });
+    }
+
+    if (sampleFields.length) {
+        selectField(sampleFields[0].id);
+    }
 })();


### PR DESCRIPTION
## Summary
- replace the ePub designer markup with a canvas workspace and floating formatting toolbar for field-specific styling
- refresh the designer styles to deliver the requested 1100x700 responsive simulator inspired by the provided reference UI
- rebuild the Konva script to render sample book content, expose live formatting controls, and support scrolling/selection of every field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f4cc1ea88332b0a727d24680ed06