### PR TITLE
Ensure Konva loads early for ePub designer and drop paragraph override

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -3860,7 +3860,10 @@ function bookcreator_admin_enqueue( $hook ) {
     $dependencies = array( 'jquery' );
 
     if ( 'book_creator' === $screen->post_type ) {
-        wp_enqueue_script( 'konva', 'https://cdn.jsdelivr.net/npm/konva@9.3.0/konva.min.js', array(), '9.3.0', true );
+        if ( ! wp_script_is( 'konva', 'registered' ) ) {
+            wp_register_script( 'konva', 'https://cdn.jsdelivr.net/npm/konva@9.3.0/konva.min.js', array(), '9.3.0', false );
+        }
+        wp_enqueue_script( 'konva' );
         $dependencies[] = 'konva';
     }
 
@@ -3884,6 +3887,19 @@ function bookcreator_admin_enqueue( $hook ) {
     );
 }
 add_action( 'admin_enqueue_scripts', 'bookcreator_admin_enqueue' );
+
+function bookcreator_epub_designer_enqueue_assets( $hook ) {
+    if ( 'book_creator_page_bc-epub-designer' !== $hook ) {
+        return;
+    }
+
+    if ( ! wp_script_is( 'konva', 'registered' ) ) {
+        wp_register_script( 'konva', 'https://cdn.jsdelivr.net/npm/konva@9.3.0/konva.min.js', array(), '9.3.0', false );
+    }
+
+    wp_enqueue_script( 'konva' );
+}
+add_action( 'admin_enqueue_scripts', 'bookcreator_epub_designer_enqueue_assets' );
 
 function bookcreator_save_chapter_meta( $post_id ) {
     if ( ! isset( $_POST['bookcreator_chapter_meta_nonce'] ) || ! wp_verify_nonce( $_POST['bookcreator_chapter_meta_nonce'], 'bookcreator_save_chapter_meta' ) ) {

--- a/templates/admin-epub-designer.php
+++ b/templates/admin-epub-designer.php
@@ -28,12 +28,6 @@ body.bookcreator-epub-designer-fullscreen {
     color: #111827;
 }
 
-.bookcreator-epub-designer-overlay p {
-    font-size: 1rem;
-    line-height: 1.6;
-    margin: 0 0 1em;
-}
-
 .bookcreator-epub-designer-overlay .designer-container {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- register the Konva script and enqueue it when opening the ePub designer so the color picker can initialise correctly
- remove the global paragraph rule from the designer overlay styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d94581e7e4833299eabf1ae4b94c49