### PR TITLE
Add template switcher and normalize EPUB markup

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -8295,9 +8295,27 @@ function bookcreator_prepare_epub_content( $content ) {
     return $filtered;
 }
 
+function bookcreator_normalize_epub_body( $body ) {
+    if ( '' === $body || null === $body ) {
+        return '';
+    }
+
+    $body = (string) $body;
+
+    if ( function_exists( 'force_balance_tags' ) ) {
+        $body = force_balance_tags( $body );
+    }
+
+    $body = preg_replace( '#\s+$#', '', $body );
+
+    return $body;
+}
+
 function bookcreator_build_epub_document( $title, $body, $language = 'en' ) {
     $language      = $language ? strtolower( str_replace( '_', '-', $language ) ) : 'en';
     $language_attr = bookcreator_escape_xml( $language );
+
+    $body = bookcreator_normalize_epub_body( $body );
 
     $document  = '<?xml version="1.0" encoding="utf-8"?>' . "\n";
     $document .= '<!DOCTYPE html>' . "\n";


### PR DESCRIPTION
## Summary
- add a template selector dropdown and shortcut button for new templates to the ePub designer header, including styling and navigation logic
- populate the selector with available templates, providing fallback labels and ordering for unnamed entries
- normalize generated EPUB body markup to avoid mismatched closing tags in the final document

## Testing
- php -l templates/admin-epub-designer.php
- php -l bookcreator.php

------
https://chatgpt.com/codex/tasks/task_e_68da4fe2d3c083328b46268528cfba29