### PR TITLE
Add stylable ePub section heading fields

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -3955,8 +3955,14 @@ function bookcreator_get_epub_designer_field_definitions() {
         'bc_publisher'      => array(
             'label' => __( 'Editore', 'bookcreator' ),
         ),
+        'dedication_title'  => array(
+            'label' => __( 'Titolo sezione Dedica', 'bookcreator' ),
+        ),
         'bc_dedication'     => array(
             'label' => __( 'Dedica', 'bookcreator' ),
+        ),
+        'preface_title'     => array(
+            'label' => __( 'Titolo sezione Prefazione', 'bookcreator' ),
         ),
         'bc_preface'        => array(
             'label' => __( 'Prefazione', 'bookcreator' ),
@@ -3967,11 +3973,17 @@ function bookcreator_get_epub_designer_field_definitions() {
         'bc_description'    => array(
             'label' => __( 'Descrizione Libro', 'bookcreator' ),
         ),
+        'copyright_title'   => array(
+            'label' => __( 'Titolo sezione Copyright', 'bookcreator' ),
+        ),
         'bc_copyright'      => array(
             'label' => __( 'Sezione Copyright', 'bookcreator' ),
         ),
         'bc_isbn'           => array(
             'label' => __( 'Codice ISBN', 'bookcreator' ),
+        ),
+        'toc_heading'       => array(
+            'label' => __( 'Intestazione indice', 'bookcreator' ),
         ),
         'table_of_contents' => array(
             'label' => __( 'Indice', 'bookcreator' ),
@@ -3994,11 +4006,20 @@ function bookcreator_get_epub_designer_field_definitions() {
         'bc_citations'      => array(
             'label' => __( 'Citazioni del Paragrafo', 'bookcreator' ),
         ),
+        'appendix_title'    => array(
+            'label' => __( 'Titolo sezione Appendice', 'bookcreator' ),
+        ),
         'bc_appendix'       => array(
             'label' => __( 'Appendice', 'bookcreator' ),
         ),
+        'bibliography_title'=> array(
+            'label' => __( 'Titolo sezione Bibliografia', 'bookcreator' ),
+        ),
         'bc_bibliography'   => array(
             'label' => __( 'Bibliografia', 'bookcreator' ),
+        ),
+        'author_note_title' => array(
+            'label' => __( 'Titolo sezione Nota dell\'autore', 'bookcreator' ),
         ),
         'bc_author_note'    => array(
             'label' => __( 'Nota Autore', 'bookcreator' ),
@@ -4014,12 +4035,16 @@ function bookcreator_get_epub_designer_selector_map() {
         'bc_subtitle'       => array( '.bookcreator-book-header__subtitle' ),
         'publisher_image'   => array( '.bookcreator-book-header__publisher-logo', '.bookcreator-book-header__publisher-logo-image', '.bookcreator-book-header__publisher-logo img' ),
         'bc_publisher'      => array( '.bookcreator-book-header__publisher' ),
+        'dedication_title'  => array( '.bookcreator-dedication__title' ),
         'bc_description'    => array( '.bookcreator-book-header__description' ),
         'bc_dedication'     => array( '.bookcreator-dedication', '.bookcreator-section-dedication', '.bookcreator-section-bc_dedication' ),
+        'preface_title'     => array( '.bookcreator-preface__title' ),
         'bc_preface'        => array( '.bookcreator-preface', '.bookcreator-preface__content' ),
         'bc_acknowledgments'=> array( '.bookcreator-acknowledgments', '.bookcreator-section-bc_acknowledgments', '.bookcreator-section-acknowledgments' ),
+        'copyright_title'   => array( '.bookcreator-copyright__title' ),
         'bc_copyright'      => array( '.bookcreator-copyright' ),
         'bc_isbn'           => array( '.bookcreator-book-header__isbn' ),
+        'toc_heading'       => array( '.bookcreator-book__index-title', '.bookcreator-preface__index-title', '#toc .bookcreator-book__index-title' ),
         'table_of_contents' => array( '.bookcreator-preface__index', '.bookcreator-book__index', '.bookcreator-preface__index-list', '#toc' ),
         'chapter_title'     => array( '.bookcreator-chapter__title' ),
         'chapter_content'   => array( '.bookcreator-chapter__content' ),
@@ -4027,8 +4052,11 @@ function bookcreator_get_epub_designer_selector_map() {
         'paragraph_content' => array( '.bookcreator-paragraph__content' ),
         'bc_footnotes'      => array( '.bookcreator-footnotes' ),
         'bc_citations'      => array( '.bookcreator-citations' ),
+        'appendix_title'    => array( '.bookcreator-section-bc_appendix__title', '.bookcreator-section-bc_appendix .bookcreator-section__title' ),
         'bc_appendix'       => array( '.bookcreator-section-bc_appendix', '.bookcreator-appendix' ),
+        'bibliography_title'=> array( '.bookcreator-section-bc_bibliography__title', '.bookcreator-section-bc_bibliography .bookcreator-section__title' ),
         'bc_bibliography'   => array( '.bookcreator-section-bc_bibliography', '.bookcreator-bibliography' ),
+        'author_note_title' => array( '.bookcreator-section-bc_author_note__title', '.bookcreator-section-bc_author_note .bookcreator-section__title' ),
         'bc_author_note'    => array( '.bookcreator-section-bc_author_note', '.bookcreator-author-note' ),
     );
 }
@@ -4041,20 +4069,27 @@ function bookcreator_get_epub_designer_template_mapping() {
         'bc_subtitle'       => 'book_subtitle',
         'publisher_image'   => 'book_publisher_logo',
         'bc_publisher'      => 'book_publisher',
+        'dedication_title'  => 'book_dedication_title',
         'bc_description'    => 'book_description',
         'bc_dedication'     => 'book_dedication',
+        'preface_title'     => 'book_preface_title',
         'bc_preface'        => 'book_preface_content',
         'bc_acknowledgments'=> 'book_acknowledgments',
+        'copyright_title'   => 'book_copyright_title',
         'bc_copyright'      => 'book_copyright',
         'table_of_contents' => 'book_index',
+        'toc_heading'       => 'book_index_title',
         'chapter_title'     => 'chapter_titles',
         'chapter_content'   => 'chapter_content',
         'paragraph_title'   => 'paragraph_titles',
         'paragraph_content' => 'paragraph_content',
         'bc_footnotes'      => 'paragraph_footnotes',
         'bc_citations'      => 'paragraph_citations',
+        'appendix_title'    => 'book_appendix_title',
         'bc_appendix'       => 'book_appendix',
+        'bibliography_title'=> 'book_bibliography_title',
         'bc_bibliography'   => 'book_bibliography',
+        'author_note_title' => 'book_author_note_title',
         'bc_author_note'    => 'book_author_note',
         'bc_isbn'           => 'book_isbn',
     );
@@ -5645,9 +5680,19 @@ function bookcreator_get_epub_style_fields() {
             'selectors' => array( '.bookcreator-book__index-list', '.bookcreator-book__index-sublist', '.bookcreator-preface__index-list', '.bookcreator-preface__index-sublist', '#toc .bookcreator-book__index-list', '#toc .bookcreator-book__index-sublist' ),
             'stylable'  => true,
         ),
+        'book_copyright_title' => array(
+            'label'     => __( 'Titolo sezione Copyright', 'bookcreator' ),
+            'selectors' => array( '.bookcreator-copyright__title' ),
+            'stylable'  => true,
+        ),
         'book_copyright' => array(
             'label'     => __( 'Sezione Copyright', 'bookcreator' ),
             'selectors' => array( '.bookcreator-copyright' ),
+            'stylable'  => true,
+        ),
+        'book_dedication_title' => array(
+            'label'     => __( 'Titolo sezione Dedica', 'bookcreator' ),
+            'selectors' => array( '.bookcreator-dedication__title' ),
             'stylable'  => true,
         ),
         'book_dedication' => array(
@@ -5675,14 +5720,29 @@ function bookcreator_get_epub_style_fields() {
             'selectors' => array( '.bookcreator-preface__content' ),
             'stylable'  => true,
         ),
+        'book_appendix_title' => array(
+            'label'     => __( 'Titolo sezione Appendice', 'bookcreator' ),
+            'selectors' => array( '.bookcreator-section-bc_appendix__title', '.bookcreator-section-bc_appendix .bookcreator-section__title' ),
+            'stylable'  => true,
+        ),
         'book_appendix' => array(
             'label'     => __( 'Sezione Appendice', 'bookcreator' ),
             'selectors' => array( '.bookcreator-section-bc_appendix' ),
             'stylable'  => true,
         ),
+        'book_bibliography_title' => array(
+            'label'     => __( 'Titolo sezione Bibliografia', 'bookcreator' ),
+            'selectors' => array( '.bookcreator-section-bc_bibliography__title', '.bookcreator-section-bc_bibliography .bookcreator-section__title' ),
+            'stylable'  => true,
+        ),
         'book_bibliography' => array(
             'label'     => __( 'Sezione Bibliografia', 'bookcreator' ),
             'selectors' => array( '.bookcreator-section-bc_bibliography' ),
+            'stylable'  => true,
+        ),
+        'book_author_note_title' => array(
+            'label'     => __( 'Titolo sezione Nota dell\'autore', 'bookcreator' ),
+            'selectors' => array( '.bookcreator-section-bc_author_note__title', '.bookcreator-section-bc_author_note .bookcreator-section__title' ),
             'stylable'  => true,
         ),
         'book_author_note' => array(
@@ -9188,7 +9248,7 @@ XML;
     $copyright_entry = null;
     if ( bookcreator_epub_designer_field_visible( $designer_settings, 'bc_copyright', (bool) $copyright_items || $legal_notice ) && ( $copyright_items || $legal_notice ) ) {
         $copyright_body  = '<div class="bookcreator-copyright">';
-        $copyright_body .= '<h1>' . esc_html( $copyright_section_title ) . '</h1>';
+        $copyright_body .= '<h1 class="bookcreator-section__title bookcreator-copyright__title">' . esc_html( $copyright_section_title ) . '</h1>';
 
         if ( $copyright_items ) {
             $copyright_body .= '<dl class="bookcreator-copyright__meta">';
@@ -9271,7 +9331,7 @@ XML;
 
     if ( $dedication && bookcreator_epub_designer_field_visible( $designer_settings, 'bc_dedication', true ) ) {
         $dedication_body  = '<div class="bookcreator-dedication">';
-        $dedication_body .= '<h1>' . esc_html( $dedication_section_title ) . '</h1>';
+        $dedication_body .= '<h1 class="bookcreator-section__title bookcreator-dedication__title">' . esc_html( $dedication_section_title ) . '</h1>';
         $dedication_body .= bookcreator_prepare_epub_content( $dedication );
         $dedication_body .= '</div>';
         $dedication_body  = bookcreator_process_epub_images( $dedication_body, $assets, $asset_map );
@@ -9290,7 +9350,7 @@ XML;
     $toc_visible             = $ordered_chapters && bookcreator_epub_designer_field_visible( $designer_settings, 'table_of_contents', true );
     if ( $preface_content_visible || $toc_visible ) {
         $preface_body  = '<div class="bookcreator-preface">';
-        $preface_body .= '<h1 class="bookcreator-preface__title">' . esc_html( $preface_section_title ) . '</h1>';
+        $preface_body .= '<h1 class="bookcreator-section__title bookcreator-preface__title">' . esc_html( $preface_section_title ) . '</h1>';
 
         $preface_body .= '<div class="bookcreator-preface__content">';
 
@@ -9478,7 +9538,7 @@ XML;
         }
 
         $section_body  = '<div class="bookcreator-section bookcreator-section-' . esc_attr( $meta_key ) . '">';
-        $section_body .= '<h1>' . esc_html( $section['title'] ) . '</h1>';
+        $section_body .= '<h1 class="bookcreator-section__title bookcreator-section-' . esc_attr( $meta_key ) . '__title">' . esc_html( $section['title'] ) . '</h1>';
         $section_body .= bookcreator_prepare_epub_content( $content );
         $section_body .= '</div>';
         $section_body  = bookcreator_process_epub_images( $section_body, $assets, $asset_map );
@@ -10066,7 +10126,7 @@ function bookcreator_generate_pdf_from_book( $book_id, $template_id = '', $targe
 
     if ( $copyright_items || $legal_notice ) {
         $copyright_html  = '<div class="bookcreator-copyright">';
-        $copyright_html .= '<h1>' . esc_html( $copyright_section_title ) . '</h1>';
+        $copyright_html .= '<h1 class="bookcreator-section__title bookcreator-copyright__title">' . esc_html( $copyright_section_title ) . '</h1>';
 
         if ( $copyright_items ) {
             $copyright_html .= '<dl class="bookcreator-copyright__meta">';
@@ -10089,7 +10149,7 @@ function bookcreator_generate_pdf_from_book( $book_id, $template_id = '', $targe
 
     if ( $dedication ) {
         $dedication_html  = '<div class="bookcreator-section bookcreator-section-dedication bookcreator-dedication">';
-        $dedication_html .= '<h1>' . esc_html( $dedication_section_title ) . '</h1>';
+        $dedication_html .= '<h1 class="bookcreator-section__title bookcreator-dedication__title">' . esc_html( $dedication_section_title ) . '</h1>';
         $dedication_html .= bookcreator_prepare_epub_content( $dedication );
         $dedication_html .= '</div>';
         $body_parts[]      = $dedication_html;
@@ -10097,7 +10157,7 @@ function bookcreator_generate_pdf_from_book( $book_id, $template_id = '', $targe
 
     if ( $preface ) {
         $preface_html  = '<div class="bookcreator-section bookcreator-section-preface bookcreator-preface">';
-        $preface_html .= '<h1 class="bookcreator-preface__title">' . esc_html( $preface_section_title ) . '</h1>';
+        $preface_html .= '<h1 class="bookcreator-section__title bookcreator-preface__title">' . esc_html( $preface_section_title ) . '</h1>';
         $preface_html .= '<div class="bookcreator-preface__content">';
         $preface_html .= bookcreator_prepare_epub_content( $preface );
         $preface_html .= '</div>';
@@ -10116,7 +10176,7 @@ function bookcreator_generate_pdf_from_book( $book_id, $template_id = '', $targe
 
     if ( $acknowledgments ) {
         $ack_html  = '<div class="bookcreator-section bookcreator-section-acknowledgments bookcreator-acknowledgments">';
-        $ack_html .= '<h1>' . esc_html( $ack_section_title ) . '</h1>';
+        $ack_html .= '<h1 class="bookcreator-section__title bookcreator-section-acknowledgments__title">' . esc_html( $ack_section_title ) . '</h1>';
         $ack_html .= bookcreator_prepare_epub_content( $acknowledgments );
         $ack_html .= '</div>';
         $body_parts[] = $ack_html;
@@ -10248,7 +10308,7 @@ function bookcreator_generate_pdf_from_book( $book_id, $template_id = '', $targe
         );
         $section_classes = array_map( 'sanitize_html_class', $section_classes );
         $section_html    = '<div class="' . esc_attr( implode( ' ', $section_classes ) ) . '">';
-        $section_html .= '<h1>' . esc_html( $section['title'] ) . '</h1>';
+        $section_html .= '<h1 class="bookcreator-section__title bookcreator-section-' . esc_attr( $section['slug'] ) . '__title bookcreator-section-' . esc_attr( $meta_key ) . '__title">' . esc_html( $section['title'] ) . '</h1>';
         $section_html .= bookcreator_prepare_epub_content( $content );
         $section_html .= '</div>';
         $body_parts[]   = $section_html;

--- a/templates/admin-epub-designer.php
+++ b/templates/admin-epub-designer.php
@@ -834,10 +834,36 @@ form#bookcreator-epub-designer-form {
                             📄 Contenuti Preliminari
                             <span>▼</span>
                         </div>
+                        <div class="field-item" data-field-id="dedication_title" data-field-name="Titolo sezione Dedica">
+                            <div class="field-info">
+                                <div class="field-name">Titolo sezione Dedica</div>
+                                <div class="field-type">dedication_title</div>
+                            </div>
+                            <div class="field-actions">
+                                <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
+                                    <input type="checkbox" class="visibility-checkbox" checked />
+                                    <span class="visibility-indicator" aria-hidden="true"></span>
+                                    <span class="screen-reader-text"><?php esc_html_e( 'Mostra questo campo', 'bookcreator' ); ?></span>
+                                </label>
+                            </div>
+                        </div>
                         <div class="field-item" data-field-id="bc_dedication" data-field-name="Dedica">
                             <div class="field-info">
                                 <div class="field-name">Dedica</div>
                                 <div class="field-type">bc_dedication</div>
+                            </div>
+                            <div class="field-actions">
+                                <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
+                                    <input type="checkbox" class="visibility-checkbox" checked />
+                                    <span class="visibility-indicator" aria-hidden="true"></span>
+                                    <span class="screen-reader-text"><?php esc_html_e( 'Mostra questo campo', 'bookcreator' ); ?></span>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="field-item" data-field-id="preface_title" data-field-name="Titolo sezione Prefazione">
+                            <div class="field-info">
+                                <div class="field-name">Titolo sezione Prefazione</div>
+                                <div class="field-type">preface_title</div>
                             </div>
                             <div class="field-actions">
                                 <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
@@ -886,6 +912,19 @@ form#bookcreator-epub-designer-form {
                                 </label>
                             </div>
                         </div>
+                        <div class="field-item" data-field-id="copyright_title" data-field-name="Titolo sezione Copyright">
+                            <div class="field-info">
+                                <div class="field-name">Titolo sezione Copyright</div>
+                                <div class="field-type">copyright_title</div>
+                            </div>
+                            <div class="field-actions">
+                                <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
+                                    <input type="checkbox" class="visibility-checkbox" checked />
+                                    <span class="visibility-indicator" aria-hidden="true"></span>
+                                    <span class="screen-reader-text"><?php esc_html_e( 'Mostra questo campo', 'bookcreator' ); ?></span>
+                                </label>
+                            </div>
+                        </div>
                         <div class="field-item" data-field-id="bc_copyright" data-field-name="Sezione Copyright">
                             <div class="field-info">
                                 <div class="field-name">Sezione Copyright</div>
@@ -903,6 +942,19 @@ form#bookcreator-epub-designer-form {
                             <div class="field-info">
                                 <div class="field-name">Codice ISBN</div>
                                 <div class="field-type">bc_isbn</div>
+                            </div>
+                            <div class="field-actions">
+                                <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
+                                    <input type="checkbox" class="visibility-checkbox" checked />
+                                    <span class="visibility-indicator" aria-hidden="true"></span>
+                                    <span class="screen-reader-text"><?php esc_html_e( 'Mostra questo campo', 'bookcreator' ); ?></span>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="field-item" data-field-id="toc_heading" data-field-name="Intestazione indice">
+                            <div class="field-info">
+                                <div class="field-name">Intestazione indice</div>
+                                <div class="field-type">toc_heading</div>
                             </div>
                             <div class="field-actions">
                                 <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
@@ -1015,6 +1067,19 @@ form#bookcreator-epub-designer-form {
                             📝 Contenuti Finali
                             <span>▼</span>
                         </div>
+                        <div class="field-item" data-field-id="appendix_title" data-field-name="Titolo sezione Appendice">
+                            <div class="field-info">
+                                <div class="field-name">Titolo sezione Appendice</div>
+                                <div class="field-type">appendix_title</div>
+                            </div>
+                            <div class="field-actions">
+                                <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
+                                    <input type="checkbox" class="visibility-checkbox" checked />
+                                    <span class="visibility-indicator" aria-hidden="true"></span>
+                                    <span class="screen-reader-text"><?php esc_html_e( 'Mostra questo campo', 'bookcreator' ); ?></span>
+                                </label>
+                            </div>
+                        </div>
                         <div class="field-item" data-field-id="bc_appendix" data-field-name="Appendice">
                             <div class="field-info">
                                 <div class="field-name">Appendice</div>
@@ -1028,10 +1093,36 @@ form#bookcreator-epub-designer-form {
                                 </label>
                             </div>
                         </div>
+                        <div class="field-item" data-field-id="bibliography_title" data-field-name="Titolo sezione Bibliografia">
+                            <div class="field-info">
+                                <div class="field-name">Titolo sezione Bibliografia</div>
+                                <div class="field-type">bibliography_title</div>
+                            </div>
+                            <div class="field-actions">
+                                <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
+                                    <input type="checkbox" class="visibility-checkbox" checked />
+                                    <span class="visibility-indicator" aria-hidden="true"></span>
+                                    <span class="screen-reader-text"><?php esc_html_e( 'Mostra questo campo', 'bookcreator' ); ?></span>
+                                </label>
+                            </div>
+                        </div>
                         <div class="field-item" data-field-id="bc_bibliography" data-field-name="Bibliografia">
                             <div class="field-info">
                                 <div class="field-name">Bibliografia</div>
                                 <div class="field-type">bc_bibliography</div>
+                            </div>
+                            <div class="field-actions">
+                                <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
+                                    <input type="checkbox" class="visibility-checkbox" checked />
+                                    <span class="visibility-indicator" aria-hidden="true"></span>
+                                    <span class="screen-reader-text"><?php esc_html_e( 'Mostra questo campo', 'bookcreator' ); ?></span>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="field-item" data-field-id="author_note_title" data-field-name="Titolo sezione Nota dell'autore">
+                            <div class="field-info">
+                                <div class="field-name">Titolo sezione Nota dell'autore</div>
+                                <div class="field-type">author_note_title</div>
                             </div>
                             <div class="field-actions">
                                 <label class="visibility-toggle" title="<?php esc_attr_e( 'Mostra o nascondi il campo', 'bookcreator' ); ?>">
@@ -1092,10 +1183,12 @@ form#bookcreator-epub-designer-form {
                                     </div>
                                 </div>
                                 <p class="epub-preview-field" data-field-id="bc_publisher" data-field-name="Editore" style="font-size: 1rem; margin-bottom: 2rem;">Edizioni Mondadori</p>
-                                <div class="epub-preview-field" data-field-id="bc_dedication" data-field-name="Dedica" style="font-size: 1rem; margin: 2rem 0;">
+                                <h1 class="epub-preview-field bookcreator-section__title bookcreator-dedication__title" data-field-id="dedication_title" data-field-name="Titolo sezione Dedica" style="font-size: 1.6rem; margin: 3rem 0 1.5rem;">Dedica</h1>
+                                <div class="epub-preview-field bookcreator-dedication" data-field-id="bc_dedication" data-field-name="Dedica" style="font-size: 1rem; margin: 0 0 2rem;">
                                     A mia nonna, che mi ha insegnato l'amore per i libri e il mistero delle storie non ancora raccontate.
                                 </div>
-                                <div class="epub-preview-field" data-field-id="bc_preface" data-field-name="Prefazione">
+                                <h1 class="epub-preview-field bookcreator-section__title bookcreator-preface__title" data-field-id="preface_title" data-field-name="Titolo sezione Prefazione" style="font-size: 1.6rem; margin: 3rem 0 1.5rem;">Prefazione</h1>
+                                <div class="epub-preview-field bookcreator-preface bookcreator-preface__content" data-field-id="bc_preface" data-field-name="Prefazione">
                                     <p>
                                         Questa storia nasce da una leggenda che ho sentito da bambino, seduto accanto al camino di casa mia.
                                         È il racconto di una biblioteca che esisteva secoli fa, custode di segreti che ancora oggi...
@@ -1112,12 +1205,14 @@ form#bookcreator-epub-designer-form {
                                         Quando la giovane archivista Elena scopre un manoscritto medievale...
                                     </p>
                                 </div>
-                                <div class="epub-preview-field" data-field-id="bc_copyright" data-field-name="Sezione Copyright">
+                                <h1 class="epub-preview-field bookcreator-section__title bookcreator-copyright__title" data-field-id="copyright_title" data-field-name="Titolo sezione Copyright" style="font-size: 1.6rem; margin: 3rem 0 1.5rem;">Copyright</h1>
+                                <div class="epub-preview-field bookcreator-copyright" data-field-id="bc_copyright" data-field-name="Sezione Copyright">
                                     <p>© 2024 Mario Rossi. Tutti i diritti riservati.</p>
                                     <p>Nessuna parte di questa pubblicazione può essere riprodotta senza autorizzazione scritta dell'editore.</p>
                                 </div>
                                 <p class="epub-preview-field" data-field-id="bc_isbn" data-field-name="Codice ISBN" style="font-size: 0.9rem; margin: 1rem 0;">ISBN: 978-88-04-12345-6</p>
-                                <div class="epub-preview-field" data-field-id="table_of_contents" data-field-name="Indice">
+                                <h2 class="epub-preview-field bookcreator-section__title bookcreator-book__index-title" data-field-id="toc_heading" data-field-name="Intestazione indice" style="font-size: 1.4rem; margin: 3rem 0 1.5rem;">Indice</h2>
+                                <div class="epub-preview-field bookcreator-preface__index bookcreator-book__index" data-field-id="table_of_contents" data-field-name="Indice">
                                     <div>
                                         <p>Prefazione ........................... 3</p>
                                         <p>Capitolo 1: La Scoperta ............. 7</p>
@@ -1144,19 +1239,22 @@ form#bookcreator-epub-designer-form {
                                     "Il sapere è come una biblioteca: più libri aggiungi, più spazio sembra mancare per quelli che ancora devi scoprire."
                                     - Umberto Eco, Il Nome della Rosa
                                 </div>
-                                <div class="epub-preview-field" data-field-id="bc_appendix" data-field-name="Appendice">
+                                <h1 class="epub-preview-field bookcreator-section__title bookcreator-section-bc_appendix__title" data-field-id="appendix_title" data-field-name="Titolo sezione Appendice" style="font-size: 1.6rem; margin: 3rem 0 1.5rem;">Appendice</h1>
+                                <div class="epub-preview-field bookcreator-section bookcreator-section-bc_appendix bookcreator-appendix" data-field-id="bc_appendix" data-field-name="Appendice">
                                     <p>1347 - Fondazione della Biblioteca del Monastero</p>
                                     <p>1398 - Prima menzione del manoscritto perduto</p>
                                     <p>1456 - Chiusura definitiva della biblioteca</p>
                                 </div>
-                                <div class="epub-preview-field" data-field-id="bc_bibliography" data-field-name="Bibliografia" style="margin: 3rem 0;">
+                                <h1 class="epub-preview-field bookcreator-section__title bookcreator-section-bc_bibliography__title" data-field-id="bibliography_title" data-field-name="Titolo sezione Bibliografia" style="font-size: 1.6rem; margin: 3rem 0 1.5rem;">Bibliografia</h1>
+                                <div class="epub-preview-field bookcreator-section bookcreator-section-bc_bibliography bookcreator-bibliography" data-field-id="bc_bibliography" data-field-name="Bibliografia" style="margin: 0 0 3rem;">
                                     <div>
                                         <p>Alberti, L. B. (1435). De re aedificatoria. Firenze: Tipografia Medicea.</p>
                                         <p>Eco, U. (1980). Il nome della rosa. Milano: Bompiani.</p>
                                         <p>Manguel, A. (1996). Una storia della lettura. Milano: Mondadori.</p>
                                     </div>
                                 </div>
-                                <div class="epub-preview-field" data-field-id="bc_author_note" data-field-name="Nota Autore">
+                                <h1 class="epub-preview-field bookcreator-section__title bookcreator-section-bc_author_note__title" data-field-id="author_note_title" data-field-name="Titolo sezione Nota dell'autore" style="font-size: 1.6rem; margin: 3rem 0 1.5rem;">Nota dell'autore</h1>
+                                <div class="epub-preview-field bookcreator-section bookcreator-section-bc_author_note bookcreator-author-note" data-field-id="bc_author_note" data-field-name="Nota Autore">
                                     <p>
                                         Questo romanzo è frutto di anni di ricerca negli archivi storici italiani.
                                         Sebbene i personaggi siano immaginari, molti dei documenti e delle location descritte sono reali.


### PR DESCRIPTION
## Summary
- add the missing section title fields to the ePub designer sidebar and preview so they can be toggled and styled
- map the new fields to ePub style definitions and selectors, and expose matching classes in the generated markup
- adjust ePub/PDF rendering to render the new heading classes so designer styles and visibility rules apply

## Testing
- php -l bookcreator/bookcreator.php
- php -l bookcreator/templates/admin-epub-designer.php

------
https://chatgpt.com/codex/tasks/task_e_68daad6dc43c83328c46a247960e286c