### PR TITLE
Aggiorna font disponibili e pesi per il designer ePub

### DIFF
--- a/templates/admin-epub-designer.php
+++ b/templates/admin-epub-designer.php
@@ -1419,10 +1419,13 @@ form#bookcreator-epub-designer-form {
                         <div class="property-row">
                             <label class="property-label">Famiglia Font</label>
                             <select class="select-input" data-style-property="font-family">
-                                <option value="Arial, sans-serif">Arial, sans-serif</option>
-                                <option value="Georgia, serif">Georgia, serif</option>
-                                <option value="\"Times New Roman\", serif">Times New Roman, serif</option>
-                                <option value="Helvetica, sans-serif">Helvetica, sans-serif</option>
+                                <option value=""><?php esc_html_e( 'Seleziona un font', 'bookcreator' ); ?></option>
+                                <option value="times" data-font-css="&quot;Times New Roman&quot;, &quot;Liberation Serif&quot;, &quot;Times&quot;, serif" data-font-generic="serif">Times</option>
+                                <option value="georgia" data-font-css="&quot;Georgia&quot;, &quot;Times New Roman&quot;, serif" data-font-generic="serif">Georgia</option>
+                                <option value="palatino" data-font-css="&quot;Palatino Linotype&quot;, &quot;Book Antiqua&quot;, serif" data-font-generic="serif">Palatino</option>
+                                <option value="arial" data-font-css="&quot;Arial&quot;, &quot;Helvetica Neue&quot;, &quot;Liberation Sans&quot;, sans-serif" data-font-generic="sans-serif">Arial</option>
+                                <option value="verdana" data-font-css="&quot;Verdana&quot;, &quot;Geneva&quot;, sans-serif" data-font-generic="sans-serif">Verdana</option>
+                                <option value="trebuchet" data-font-css="&quot;Trebuchet MS&quot;, &quot;Lucida Grande&quot;, sans-serif" data-font-generic="sans-serif">Trebuchet</option>
                             </select>
                         </div>
                         <div class="property-row-split">
@@ -1439,9 +1442,8 @@ form#bookcreator-epub-designer-form {
                             <div>
                                 <label class="property-label">Peso Font</label>
                                 <select class="select-input" data-style-property="font-weight">
-                                    <option value="400">400 - Normal</option>
-                                    <option value="600">600 - Semi Bold</option>
-                                    <option value="700">700 - Bold</option>
+                                    <option value="400">400 - Normale</option>
+                                    <option value="700">700 - Grassetto</option>
                                 </select>
                             </div>
                             <div>


### PR DESCRIPTION
## Summary
- sostituiti i font del designer con le famiglie EPUB consentite e aggiunti metadati per i fallback generici
- aggiornate le opzioni del peso del font per riflettere i pesi disponibili delle famiglie supportate

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db8b8c9b108332ae4f532b35eef2b4