### PR TITLE
Sincronizza font del designer con le opzioni EPUB

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -5124,28 +5124,40 @@ function bookcreator_is_epub_library_available() {
 function bookcreator_get_epub_font_family_options() {
     return array(
         'times'           => array(
-            'label' => __( 'Times New Roman / Liberation Serif / Times', 'bookcreator' ),
-            'css'   => "\"Times New Roman\", \"Liberation Serif\", \"Times\", serif",
+            'label'          => __( 'Times New Roman / Liberation Serif / Times', 'bookcreator' ),
+            'designer_label' => __( 'Times', 'bookcreator' ),
+            'css'            => '"Times New Roman", "Liberation Serif", "Times", serif',
+            'generic'        => 'serif',
         ),
         'georgia'         => array(
-            'label' => __( 'Georgia / Times New Roman', 'bookcreator' ),
-            'css'   => "\"Georgia\", \"Times New Roman\", serif",
+            'label'          => __( 'Georgia / Times New Roman', 'bookcreator' ),
+            'designer_label' => __( 'Georgia', 'bookcreator' ),
+            'css'            => '"Georgia", "Times New Roman", serif',
+            'generic'        => 'serif',
         ),
         'palatino'        => array(
-            'label' => __( 'Palatino Linotype / Book Antiqua', 'bookcreator' ),
-            'css'   => "\"Palatino Linotype\", \"Book Antiqua\", serif",
+            'label'          => __( 'Palatino Linotype / Book Antiqua', 'bookcreator' ),
+            'designer_label' => __( 'Palatino', 'bookcreator' ),
+            'css'            => '"Palatino Linotype", "Book Antiqua", serif',
+            'generic'        => 'serif',
         ),
         'arial'           => array(
-            'label' => __( 'Arial / Helvetica Neue / Liberation Sans', 'bookcreator' ),
-            'css'   => "\"Arial\", \"Helvetica Neue\", \"Liberation Sans\", sans-serif",
+            'label'          => __( 'Arial / Helvetica Neue / Liberation Sans', 'bookcreator' ),
+            'designer_label' => __( 'Arial', 'bookcreator' ),
+            'css'            => '"Arial", "Helvetica Neue", "Liberation Sans", sans-serif',
+            'generic'        => 'sans-serif',
         ),
         'verdana'         => array(
-            'label' => __( 'Verdana / Geneva', 'bookcreator' ),
-            'css'   => "\"Verdana\", \"Geneva\", sans-serif",
+            'label'          => __( 'Verdana / Geneva', 'bookcreator' ),
+            'designer_label' => __( 'Verdana', 'bookcreator' ),
+            'css'            => '"Verdana", "Geneva", sans-serif',
+            'generic'        => 'sans-serif',
         ),
         'trebuchet'       => array(
-            'label' => __( 'Trebuchet MS / Lucida Grande', 'bookcreator' ),
-            'css'   => "\"Trebuchet MS\", \"Lucida Grande\", sans-serif",
+            'label'          => __( 'Trebuchet MS / Lucida Grande', 'bookcreator' ),
+            'designer_label' => __( 'Trebuchet', 'bookcreator' ),
+            'css'            => '"Trebuchet MS", "Lucida Grande", sans-serif',
+            'generic'        => 'sans-serif',
         ),
     );
 }

--- a/templates/admin-epub-designer.php
+++ b/templates/admin-epub-designer.php
@@ -1412,6 +1412,7 @@ form#bookcreator-epub-designer-form {
                             </div>
                         </div>
                     </div>
+                    <?php $designer_font_families = bookcreator_get_epub_font_family_options(); ?>
                     <div class="property-group style-property-group">
                         <div class="property-group-title">
                             🅰️ Tipografia
@@ -1419,10 +1420,20 @@ form#bookcreator-epub-designer-form {
                         <div class="property-row">
                             <label class="property-label">Famiglia Font</label>
                             <select class="select-input" data-style-property="font-family">
-                                <option value="Arial, sans-serif">Arial, sans-serif</option>
-                                <option value="Georgia, serif">Georgia, serif</option>
-                                <option value="\"Times New Roman\", serif">Times New Roman, serif</option>
-                                <option value="Helvetica, sans-serif">Helvetica, sans-serif</option>
+                                <option value=""><?php esc_html_e( 'Seleziona un font', 'bookcreator' ); ?></option>
+                                <?php foreach ( $designer_font_families as $font_key => $font_data ) :
+                                    $font_label   = isset( $font_data['designer_label'] ) && $font_data['designer_label']
+                                        ? $font_data['designer_label']
+                                        : $font_data['label'];
+                                    $font_css     = isset( $font_data['css'] ) ? $font_data['css'] : '';
+                                    $font_generic = isset( $font_data['generic'] ) ? $font_data['generic'] : '';
+                                    ?>
+                                    <option
+                                        value="<?php echo esc_attr( $font_key ); ?>"
+                                        data-font-css="<?php echo esc_attr( $font_css ); ?>"
+                                        <?php if ( $font_generic ) : ?>data-font-generic="<?php echo esc_attr( $font_generic ); ?>"<?php endif; ?>
+                                    ><?php echo esc_html( $font_label ); ?></option>
+                                <?php endforeach; ?>
                             </select>
                         </div>
                         <div class="property-row-split">
@@ -1439,9 +1450,8 @@ form#bookcreator-epub-designer-form {
                             <div>
                                 <label class="property-label">Peso Font</label>
                                 <select class="select-input" data-style-property="font-weight">
-                                    <option value="400">400 - Normal</option>
-                                    <option value="600">600 - Semi Bold</option>
-                                    <option value="700">700 - Bold</option>
+                                    <option value="400">400 - Normale</option>
+                                    <option value="700">700 - Grassetto</option>
                                 </select>
                             </div>
                             <div>


### PR DESCRIPTION
## Summary
- aggiunti metadati di etichetta breve e famiglia generica all'elenco canonico dei font EPUB
- popolato dinamicamente il menu a tendina della tipografia nel designer usando l'elenco dei font supportati

## Testing
- php -l bookcreator.php
- php -l templates/admin-epub-designer.php

------
https://chatgpt.com/codex/tasks/task_e_68db8b8c9b108332ae4f532b35eef2b4