### PR TITLE
Fix translation loading directory path

### DIFF
--- a/bookcreator.php
+++ b/bookcreator.php
@@ -122,7 +122,7 @@ function bookcreator_is_pdf_library_available() {
  * Load plugin textdomain.
  */
 function bookcreator_load_textdomain() {
-    load_plugin_textdomain( 'bookcreator', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    load_plugin_textdomain( 'bookcreator', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 }
 add_action( 'plugins_loaded', 'bookcreator_load_textdomain' );
 


### PR DESCRIPTION
## Summary
- ensure the plugin text domain loader points to the languages directory with a trailing slash so translations are detected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf06e83dc83328eb12536514c0e85