### PR TITLE
Apply publisher page break and improve PDF fonts

### DIFF
--- a/templates/admin-pdf-designer.php
+++ b/templates/admin-pdf-designer.php
@@ -90,6 +90,7 @@ $designer_initial_payload = wp_json_encode(
 if ( ! $designer_initial_payload ) {
     $designer_initial_payload = '{}';
 }
+$designer_font_faces_css = bookcreator_generate_pdf_font_face_css();
 ?>
 <script>
 window.bookcreatorDesignerInitialData = <?php echo $designer_initial_payload; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
@@ -98,6 +99,9 @@ window.bookcreatorDesignerPageFormats = <?php echo $designer_page_formats_json; 
 window.bookcreatorDesignerPageDimensions = <?php echo $designer_page_dimensions_json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 </script>
 <style>
+<?php if ( $designer_font_faces_css ) : ?>
+<?php echo $designer_font_faces_css; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<?php endif; ?>
 body.bookcreator-pdf-designer-fullscreen {
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- ensure the publisher logo width percent is honoured even when set from the PDF designer and move post-publisher content after a forced page break
- register every bundled mPDF font for the PDF designer preview by emitting @font-face rules so selected fonts render in the UI and remain available for export
- render the generated PDF with a book-title page header for both odd and even pages while styling it consistently

## Testing
- php -l bookcreator.php
- php -l templates/admin-pdf-designer.php

------
https://chatgpt.com/codex/tasks/task_e_68dd0cf6596483328f20acb463a0a810